### PR TITLE
Revert "PHP7 updates/cosmetics"

### DIFF
--- a/2019-phpsecinfo-v3.0.1/CHANGELOG
+++ b/2019-phpsecinfo-v3.0.1/CHANGELOG
@@ -1,6 +1,3 @@
-3.02  2020-07-10 (mambax7)
-- PHP7 updates/cosmetics
-
 ################################################
 #     v3.0.1 2019-2020 - Version Zer00CooL     #
 ################################################
@@ -14,12 +11,12 @@ Ajout d'une fin de ligne vide à la fin de chaque fichier.
 Indentation des fichiers aux normes PSR-2.
 Ajout du fichier phpinfo() et un lien de retour vers PhpSecInfo.
 
-# # # # # # # # # # # # # # # # # # #
+# # # # # # # # # # # # # # # # # # #
 ###### A inclure SecurityInfo ! ######
 Basé sur la v0.2.2, quelques modifications ont été effectuées.
 https://github.com/matomo-org/plugin-SecurityInfo/blob/master/PhpSecInfo/PhpSecInfo.php#L20
 
-# # # # # # # # # # # # # # # # # #
+# # # # # # # # # # # # # # # # # #
 ###### A inclure la v0.2.2 ! ######
 v0.2.2
 - requires are now resolved relative to base phpsecinfo path, so PhpSecInfo does

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/PhpSecInfo.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/PhpSecInfo.php
@@ -1,7 +1,7 @@
-<?php declare(strict_types=1);
-
+<?php
 /**
  * Main class file
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
@@ -25,12 +25,12 @@ define('PHPSECINFO_LANG_DEFAULT', 'fr');
  *
  * Afficher la version courante de PhpSecInfo : 3.0.1 (0.2.1 + v2.0.2)
  */
-define('PHPSECINFO_VERSION', '3.0.2');
+define('PHPSECINFO_VERSION', '3.0.1');
 
 /**
  * A YYYY.MM.DD date string to indicate "build" date
  */
-define('PHPSECINFO_BUILD', date('d-m-Y'));
+define('PHPSECINFO_BUILD', date("d-m-Y"));
 
 /**
  * Homepage for phpsecinfo project
@@ -73,21 +73,22 @@ define('PHPSECINFO_URL', 'http://phpsec.org/projects/phpsecinfo/');
  *
  * The procedural function "phpsecinfo" is defined below this class.
  *
- * @see    phpsecinfo()
+ * @see phpsecinfo()
  *
  * @author Ed Finkler <coj@funkatron.com>
- *
+ *        
  *         see CHANGELOG for changes
+ *        
  */
 class PhpSecInfo
 {
+
     /**
      * An array of tests to run
      *
      * @public array PhpSecInfo_Test
      */
-
-    public $tests_to_run = [];
+    public $tests_to_run = array();
 
     /**
      * An array of results.
@@ -99,8 +100,7 @@ class PhpSecInfo
      *
      * @public array
      */
-
-    public $test_results = [];
+    public $test_results = array();
 
     /**
      * An array of tests that were not run
@@ -112,8 +112,7 @@ class PhpSecInfo
      *
      * @public array
      */
-
-    public $tests_not_run = [];
+    public $tests_not_run = array();
 
     /**
      * The language code used.
@@ -121,9 +120,8 @@ class PhpSecInfo
      * is 'en'
      *
      * @public string
-     * @see    PHPSECINFO_LANG_DEFAULT
+     * @see PHPSECINFO_LANG_DEFAULT
      */
-
     public $language = PHPSECINFO_LANG_DEFAULT;
 
     /**
@@ -133,40 +131,38 @@ class PhpSecInfo
      *
      * @public array
      */
-
-    public $result_counts = [];
+    public $result_counts = array();
 
     /**
      * The number of tests that have been run
      *
      * @public integer
      */
-
     public $num_tests_run = 0;
 
     /**
      * Constructor
+     *
+     * @return PhpSecInfo
      */
-    public function __construct()
-    {
-    }
+    function PhpSecInfo()
+    {}
 
     /**
      * recurses through the Test subdir and includes classes in each test group subdir,
      * then builds an array of classnames for the tests that will be run
      */
-    public function loadTests()
+    function loadTests()
     {
-        $test_root = dir(__DIR__ . DIRECTORY_SEPARATOR . 'Test');
+        $test_root = dir(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Test');
 
         // echo "<pre>"; echo print_r($test_root, true); echo "</pre>";
 
         while (false !== ($entry = $test_root->read())) {
-            if (is_dir($test_root->path . DIRECTORY_SEPARATOR . $entry) && !preg_match('|^\.(.*)$|', $entry)) {
+            if (is_dir($test_root->path . DIRECTORY_SEPARATOR . $entry) && ! preg_match('|^\.(.*)$|', $entry)) {
                 $test_dirs[] = $entry;
             }
         }
-
         // echo "<pre>"; echo print_r($test_dirs, true); echo "</pre>";
 
         // include_once all files in each test dir
@@ -174,10 +170,9 @@ class PhpSecInfo
             $this_dir = dir($test_root->path . DIRECTORY_SEPARATOR . $test_dir);
 
             while (false !== ($entry = $this_dir->read())) {
-                if (!is_dir($this_dir->path . DIRECTORY_SEPARATOR . $entry)) {
+                if (! is_dir($this_dir->path . DIRECTORY_SEPARATOR . $entry)) {
                     require_once $this_dir->path . DIRECTORY_SEPARATOR . $entry;
-
-                    $classNames[] = 'PhpSecInfo_Test_' . $test_dir . '_' . basename($entry, '.php');
+                    $classNames[] = "PhpSecInfo_Test_" . $test_dir . "_" . basename($entry, '.php');
                 }
             }
         }
@@ -196,57 +191,50 @@ class PhpSecInfo
      * - $this->num_tests_run
      * - $this->tests_not_run;
      */
-    public function runTests()
+    function runTests()
     {
         // initialize a bunch of arrays
-        $this->test_results = [];
-
-        $this->result_counts = [];
-
+        $this->test_results = array();
+        $this->result_counts = array();
         $this->result_counts[PHPSECINFO_TEST_RESULT_NOTRUN] = 0;
-
         $this->num_tests_run = 0;
 
         foreach ($this->tests_to_run as $testClass) {
+
             /**
+             *
              * @public $test PhpSecInfo_Test
              */
-
             $test = new $testClass();
 
             if ($test->isTestable()) {
                 $test->test();
-
-                $rs = [
-                    'result'            => $test->getResult(),
-                    'message'           => $test->getMessage(),
-                    'value_current'     => $test->getCurrentTestValue(),
+                $rs = array(
+                    'result' => $test->getResult(),
+                    'message' => $test->getMessage(),
+                    'value_current' => $test->getCurrentTestValue(),
                     'value_recommended' => $test->getRecommendedTestValue(),
-                    'moreinfo_url'      => $test->getMoreInfoURL(),
-                ];
-
+                    'moreinfo_url' => $test->getMoreInfoURL()
+                );
                 $this->test_results[$test->getTestGroup()][$test->getTestName()] = $rs;
 
                 // Initialize if not yet set
-                if (!isset($this->result_counts[$rs['result']])) {
+                if (! isset($this->result_counts[$rs['result']])) {
                     $this->result_counts[$rs['result']] = 0;
                 }
 
-                $this->result_counts[$rs['result']]++;
-
-                $this->num_tests_run++;
+                $this->result_counts[$rs['result']] ++;
+                $this->num_tests_run ++;
             } else {
-                $rs = [
-                    'result'            => $test->getResult(),
-                    'message'           => $test->getMessage(),
-                    'value_current'     => null,
+                $rs = array(
+                    'result' => $test->getResult(),
+                    'message' => $test->getMessage(),
+                    'value_current' => null,
                     'value_recommended' => null,
-                    'moreinfo_url'      => $test->getMoreInfoURL(),
-                ];
-
-                $this->result_counts[PHPSECINFO_TEST_RESULT_NOTRUN]++;
-
-                $this->tests_not_run[$test->getTestGroup() . '::' . $test->getTestName()] = $rs;
+                    'moreinfo_url' => $test->getMoreInfoURL()
+                );
+                $this->result_counts[PHPSECINFO_TEST_RESULT_NOTRUN] ++;
+                $this->tests_not_run[$test->getTestGroup() . "::" . $test->getTestName()] = $rs;
             }
         }
     }
@@ -254,322 +242,320 @@ class PhpSecInfo
     /**
      * This is the main output method.
      * The look and feel mimics phpinfo()
-     * @param string $page_title
      */
-    public function renderOutput($page_title = 'PHP Security Information')
+    function renderOutput($page_title = "PHP Security Information")
     {
+
         /**
          * We need to use PhpSecInfo_Test::getBooleanIniValue() below
          *
          * @see PhpSecInfo_Test::getBooleanIniValue()
          */
+        if (! class_exists('PhpSecInfo_Test')) {
+            include (dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'Test.php');
+        }
 
-        if (!class_exists('PhpSecInfo_Test')) {
-            include(__DIR__ . DIRECTORY_SEPARATOR . 'Test' . DIRECTORY_SEPARATOR . 'Test.php');
-        } ?>
-        <!-- XHTML 1.0 Transitional -->
-        <!-- <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd"> -->
-        <!-- HTML5 -->
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title><?php echo $page_title ?></title>
-            <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
-            <meta name="robots" content="noindex,nofollow"/>
-            <style type="text/css">
-                .phpblue {
-                    #777BB4
+        ?>
+<!-- XHTML 1.0 Transitional -->
+<!-- <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd"> -->
+<!-- HTML5 -->
+<!DOCTYPE html>
+<html>
+<head>
+<title><?php echo $page_title ?></title>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<meta name="robots" content="noindex,nofollow" />
+<style type="text/css">
+.phpblue { #777BB4
+	
+}
+/*
+    #706464
+    #C7C6B3
+    #7B8489
+    #646B70
+    */
+BODY {
+	background-color: #C7C6B3;
+	color: #333333;
+	margin: 0;
+	padding: 0;
+	text-align: center;
+}
 
-                }
+BODY, TD, TH, H1, H2 {
+	font-family: Helvetica, Arial, Sans-serif;
+}
 
-                /*
-                    #706464
-                    #C7C6B3
-                    #7B8489
-                    #646B70
-                    */
-                BODY {
-                    background-color: #C7C6B3;
-                    color: #333333;
-                    margin: 0;
-                    padding: 0;
-                    text-align: center;
-                }
+DIV.logo {
+	float: right;
+}
 
-                BODY, TD, TH, H1, H2 {
-                    font-family: Helvetica, Arial, Sans-serif;
-                }
+A:link, A:hover, A:visited {
+	color: #000099;
+	text-decoration: none;
+}
 
-                DIV.logo {
-                    float: right;
-                }
+A:hover {
+	text-decoration: underline !important;
+}
 
-                A:link, A:hover, A:visited {
-                    color: #000099;
-                    text-decoration: none;
-                }
+DIV.container {
+	text-align: center;
+	width: 650px;
+	margin-left: auto;
+	margin-right: auto;
+}
 
-                A:hover {
-                    text-decoration: underline !important;
-                }
+DIV.header {
+	width: 100%;
+	text-align: left;
+	border-collapse: collapse;
+}
 
-                DIV.container {
-                    text-align: center;
-                    width: 650px;
-                    margin-left: auto;
-                    margin-right: auto;
-                }
+DIV.header {
+	background-color: #4C5B74;
+	color: white;
+	border-bottom: 3px solid #333333;
+	padding: .5em;
+}
 
-                DIV.header {
-                    width: 100%;
-                    text-align: left;
-                    border-collapse: collapse;
-                }
+DIV.header H1, DIV.header H2 {
+	padding: 0;
+	margin: 0;
+}
 
-                DIV.header {
-                    background-color: #4C5B74;
-                    color: white;
-                    border-bottom: 3px solid #333333;
-                    padding: .5em;
-                }
+DIV.header H2 {
+	font-size: 1em;
+}
 
-                DIV.header H1, DIV.header H2 {
-                    padding: 0;
-                    margin: 0;
-                }
+DIV.header a:link, DIV.header a:visited, DIV.header a:hover {
+	color: #ffff99;
+}
 
-                DIV.header H2 {
-                    font-size: 1em;
-                }
+H2.result-header {
+	margin: 1em 0 .5em 0;
+}
 
-                DIV.header a:link, DIV.header a:visited, DIV.header a:hover {
-                    color: #ffff99;
-                }
+TABLE.results {
+	border-collapse: collapse;
+	width: 100%;
+	text-align: left;
+}
 
-                H2.result-header {
-                    margin: 1em 0 .5em 0;
-                }
+TD, TH {
+	padding: 0.5em;
+	border: 2px solid #333333;
+}
 
-                TABLE.results {
-                    border-collapse: collapse;
-                    width: 100%;
-                    text-align: left;
-                }
+TR.header {
+	background-color: #706464;
+	color: white;
+}
 
-                TD, TH {
-                    padding: 0.5em;
-                    border: 2px solid #333333;
-                }
+TD.label {
+	text-align: top;
+	font-weight: bold;
+	background-color: #7B8489;
+	border: 2px solid #333333;
+}
 
-                TR.header {
-                    background-color: #706464;
-                    color: white;
-                }
+TD.value {
+	border: 2px solid #333333
+}
 
-                TD.label {
-                    text-align: top;
-                    font-weight: bold;
-                    background-color: #7B8489;
-                    border: 2px solid #333333;
-                }
+.centered {
+	text-align: center;
+}
 
-                TD.value {
-                    border: 2px solid #333333
-                }
+.centered TABLE {
+	text-align: left;
+}
 
-                .centered {
-                    text-align: center;
-                }
+.centered TH {
+	text-align: center;
+}
 
-                .centered TABLE {
-                    text-align: left;
-                }
+.result {
+	font-size: 1.2em;
+	font-weight: bold;
+	margin-bottom: .5em;
+}
 
-                .centered TH {
-                    text-align: center;
-                }
+.message {
+	line-height: 1.4em;
+}
 
-                .result {
-                    font-size: 1.2em;
-                    font-weight: bold;
-                    margin-bottom: .5em;
-                }
+TABLE.values {
+	padding: .5em;
+	margin: .5em;
+	text-align: left;
+	margin: none;
+	width: 90%;
+}
 
-                .message {
-                    line-height: 1.4em;
-                }
+TABLE.values TD {
+	font-size: .9em;
+	border: none;
+	padding: .4em;
+}
 
-                TABLE.values {
-                    padding: .5em;
-                    margin: .5em;
-                    text-align: left;
-                    margin: none;
-                    width: 90%;
-                }
+TABLE.values TD.label {
+	font-weight: bold;
+	text-align: right;
+	width: 45%;
+}
 
-                TABLE.values TD {
-                    font-size: .9em;
-                    border: none;
-                    padding: .4em;
-                }
+DIV.moreinfo {
+	text-align: right;
+}
 
-                TABLE.values TD.label {
-                    font-weight: bold;
-                    text-align: right;
-                    width: 45%;
-                }
+.value-ok {
+	background-color: #009900;
+	color: #ffffff;
+}
 
-                DIV.moreinfo {
-                    text-align: right;
-                }
+.value-ok a:link, .value-ok a:hover, .value-ok a:visited {
+	color: #FFFF99;
+	font-weight: bold;
+	background-color: transparent;
+	text-decoration: none;
+}
 
-                .value-ok {
-                    background-color: #009900;
-                    color: #ffffff;
-                }
+.value-ok table td {
+	background-color: #33AA33;
+	color: #ffffff;
+}
 
-                .value-ok a:link, .value-ok a:hover, .value-ok a:visited {
-                    color: #FFFF99;
-                    font-weight: bold;
-                    background-color: transparent;
-                    text-decoration: none;
-                }
+.value-notice {
+	background-color: #FFA500;
+	color: #000000;
+}
 
-                .value-ok table td {
-                    background-color: #33AA33;
-                    color: #ffffff;
-                }
+.value-notice a:link, .value-notice a:hover, .value-notice a:visited {
+	color: #000099;
+	font-weight: bold;
+	background-color: transparent;
+	text-decoration: none;
+}
 
-                .value-notice {
-                    background-color: #FFA500;
-                    color: #000000;
-                }
+.value-notice td {
+	background-color: #FFC933;
+	color: #000000;
+}
 
-                .value-notice a:link, .value-notice a:hover, .value-notice a:visited {
-                    color: #000099;
-                    font-weight: bold;
-                    background-color: transparent;
-                    text-decoration: none;
-                }
+.value-warn {
+	background-color: #990000;
+	color: #ffffff;
+}
 
-                .value-notice td {
-                    background-color: #FFC933;
-                    color: #000000;
-                }
+.value-warn a:link, .value-warn a:hover, .value-warn a:visited {
+	color: #FFFF99;
+	font-weight: bold;
+	background-color: transparent;
+	text-decoration: none;
+}
 
-                .value-warn {
-                    background-color: #990000;
-                    color: #ffffff;
-                }
+.value-warn td {
+	background-color: #AA3333;
+	color: #ffffff;
+}
 
-                .value-warn a:link, .value-warn a:hover, .value-warn a:visited {
-                    color: #FFFF99;
-                    font-weight: bold;
-                    background-color: transparent;
-                    text-decoration: none;
-                }
+.value-notrun {
+	background-color: #cccccc;
+	color: #000000;
+}
 
-                .value-warn td {
-                    background-color: #AA3333;
-                    color: #ffffff;
-                }
+.value-notrun a:link, .value-notrun a:hover, .value-notrun a:visited {
+	color: #000099;
+	font-weight: bold;
+	background-color: transparent;
+	text-decoration: none;
+}
 
-                .value-notrun {
-                    background-color: #cccccc;
-                    color: #000000;
-                }
+.value-notrun td {
+	background-color: #dddddd;
+	color: #000000;
+}
 
-                .value-notrun a:link, .value-notrun a:hover, .value-notrun a:visited {
-                    color: #000099;
-                    font-weight: bold;
-                    background-color: transparent;
-                    text-decoration: none;
-                }
+.value-error {
+	background-color: #F6AE15;
+	color: #000000;
+	font-weight: bold;
+}
 
-                .value-notrun td {
-                    background-color: #dddddd;
-                    color: #000000;
-                }
+.value-error td {
+	background-color: #F6AE15;
+	color: #000000;
+}
+</style>
+</head>
+<body>
+	<div class="header">
+		<h1><a href="<?php echo PHPSECINFO_URL ?>" target="_phpsec"><?php echo $page_title ?></a></h1>
+		<h2><?php
+        // Affiche "Version xxx"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Version ';
+                echo PHPSECINFO_VERSION;
+                break;
 
-                .value-error {
-                    background-color: #F6AE15;
-                    color: #000000;
-                    font-weight: bold;
-                }
+            default:
+                echo 'Version ';
+                echo PHPSECINFO_VERSION;
+                break;
+        }
+        ?> - <?php
+        // Affiche "Last update"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Dernière mise à jour du';
+                break;
 
-                .value-error td {
-                    background-color: #F6AE15;
-                    color: #000000;
-                }
-            </style>
-        </head>
-        <body>
-        <div class="header">
-            <h1><a href="<?php echo PHPSECINFO_URL ?>" target="_phpsec"><?php echo $page_title ?></a></h1>
-            <h2><?php
-                // Affiche "Version xxx"
-                switch (PHPSECINFO_LANG_DEFAULT) {
-                    case 'fr':
-                        echo 'Version ';
-                        echo PHPSECINFO_VERSION;
+            default:
+                echo 'Last update the';
+                break;
+        }
+        ?> <?php echo PHPSECINFO_BUILD ?> - <a href="https://github.com/ZerooCool/phpsecinfo/"
+				target="_PhpSecInfo"><?php
+        // Affiche "Participate from Github"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Participer depuis Github';
+                break;
 
-                        break;
-                    default:
-                        echo 'Version ';
-                        echo PHPSECINFO_VERSION;
+            default:
+                echo 'Participate from Github';
+                break;
+        }
+        ?></a> - <a href="PhpSecInfo/phpinfo.php"><?php
+        // Affiche "See phpinfo ()"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Consulter phpinfo()';
+                break;
 
-                        break;
-                } ?> - <?php
-                // Affiche "Last update"
-                switch (PHPSECINFO_LANG_DEFAULT) {
-                    case 'fr':
-                        echo 'Dernière mise à jour du';
+            default:
+                echo 'See phpinfo ()';
+                break;
+        }
+        ?></a>
+		</h2>
+	</div>
 
-                        break;
-                    default:
-                        echo 'Last update the';
-
-                        break;
-                } ?> <?php echo PHPSECINFO_BUILD ?> - <a href="https://github.com/ZerooCool/phpsecinfo/"
-                                                         target="_PhpSecInfo"><?php
-                    // Affiche "Participate from Github"
-                    switch (PHPSECINFO_LANG_DEFAULT) {
-                        case 'fr':
-                            echo 'Participer depuis Github';
-
-                            break;
-                        default:
-                            echo 'Participate from Github';
-
-                            break;
-                    } ?></a> - <a href="PhpSecInfo/phpinfo.php"><?php
-                    // Affiche "See phpinfo ()"
-                    switch (PHPSECINFO_LANG_DEFAULT) {
-                        case 'fr':
-                            echo 'Consulter phpinfo()';
-
-                            break;
-                        default:
-                            echo 'See phpinfo ()';
-
-                            break;
-                    } ?></a>
-            </h2>
-        </div>
-
-        <div class="container">
-            <?php
-            foreach ($this->test_results as $group_name => $group_results) {
-                $this->_outputRenderTable($group_name, $group_results);
-            }
-
-            $this->_outputRenderNotRunTable();
-
-            $this->_outputRenderStatsTable(); ?>
-        </div>
-        </body>
-        </html>
+	<div class="container">
         <?php
+        foreach ($this->test_results as $group_name => $group_results) {
+            $this->_outputRenderTable($group_name, $group_results);
+        }
+        $this->_outputRenderNotRunTable();
+        $this->_outputRenderStatsTable();
+        ?>
+    </div>
+</body>
+</html>
+<?php
     }
 
     /**
@@ -577,131 +563,126 @@ class PhpSecInfo
      * for a given test group
      *
      * @param string $group_name
-     * @param array  $group_results
-     * @return bool
+     * @param array $group_results
      */
-    public function _outputRenderTable($group_name, $group_results)
+    function _outputRenderTable($group_name, $group_results)
     {
+
         // exit out if $group_results was empty or not an array. This sorta seems a little hacky...
-        if (!is_array($group_results) || count($group_results) < 1) {
+        if (! is_array($group_results) || sizeof($group_results) < 1) {
             return false;
         }
 
         // Commenté via le code de BigDeej
         // https://github.com/bigdeej/PhpSecInfo/tree/master/PhpSecInfo/Test/Core
         // ksort($group_results);
+
         ?>
-        <h2 class="result-header"><?php echo htmlspecialchars($group_name, ENT_QUOTES) ?></h2>
+<h2 class="result-header"><?php echo htmlspecialchars($group_name, ENT_QUOTES) ?></h2>
 
-        <table class="results">
-            <tr class="header">
-                <th><?php
-                    // Affiche "Check"
+<table class="results">
+	<tr class="header">
+		<th><?php
+        // Affiche "Check"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Vérifier';
+                break;
+
+            default:
+                echo 'Check';
+                break;
+        }
+        ?></th>
+		<th><?php
+		// Affiche "Result"
+        switch (PHPSECINFO_LANG_DEFAULT) {
+            case 'fr':
+                echo 'Résultat';
+                break;
+
+            default:
+                echo 'Result';
+                break;
+        }
+        ?></th>
+	</tr>
+        <?php foreach ($group_results as $test_name => $test_results) : ?>
+        <tr>
+		<td class="label"><?php echo htmlspecialchars($test_name, ENT_QUOTES) ?></td>
+		<td
+			class="value <?php echo $this->_outputGetCssClassFromResult($test_results['result']) ?>">
+                <?php if ($group_name != 'Test Results Summary') : ?>
+                    <div class="result"><?php echo $this->_outputGetResultTypeFromCode($test_results['result']) ?></div>
+                <?php endif; ?>
+                <div class="message"><?php echo $test_results['message'] ?></div>
+
+                <?php if (isset($test_results['value_current']) || isset($test_results['value_recommended'])) : ?>
+                    <table class="values">
+                    <?php if (isset($test_results['value_current'])) : ?>
+                        <tr>
+					<td class="label"><?php
+                    // Affiche "Current Value"
                     switch (PHPSECINFO_LANG_DEFAULT) {
                         case 'fr':
-                            echo 'Vérifier';
-
+                            echo 'Valeur actuelle';
                             break;
+
                         default:
-                            echo 'Check';
-
+                            echo 'Current Value';
                             break;
-                    } ?></th>
-                <th><?php
-                    // Affiche "Result"
+                    }
+                    ?></td>
+
+					<!-- <td><?php echo $test_results['value_current'] ?></td>  -->
+					<!-- https://github.com/bigdeej/PhpSecInfo/tree/master/PhpSecInfo/Test/Core -->
+					<td><?php echo wordwrap($test_results['value_current'], 55, '<br />', true) ?></td>
+				</tr>
+                    <?php endif;?>
+                    <?php if (isset($test_results['value_recommended'])) : ?>
+                        <tr>
+					<td class="label"><?php
+                    // Affiche "Recommended Value"
                     switch (PHPSECINFO_LANG_DEFAULT) {
                         case 'fr':
-                            echo 'Résultat';
-
+                            echo 'Valeur recommandée';
                             break;
+
                         default:
-                            echo 'Result';
-
+                            echo 'Recommended Value';
                             break;
-                    } ?></th>
-            </tr>
-            <?php foreach ($group_results as $test_name => $test_results) :
-                ?>
-                <tr>
-                    <td class="label"><?php echo htmlspecialchars($test_name, ENT_QUOTES) ?></td>
-                    <td
-                            class="value <?php echo $this->_outputGetCssClassFromResult($test_results['result']) ?>">
-                        <?php if ('Test Results Summary' != $group_name) :
-                            ?>
-                            <div class="result"><?php echo $this->_outputGetResultTypeFromCode($test_results['result']) ?></div>
-                        <?php endif; ?>
-                        <div class="message"><?php echo $test_results['message'] ?></div>
+                    }
+                    ?></td>
+					<td><?php echo $test_results['value_recommended'] ?></td>
+				</tr>
+                    <?php endif; ?>
+                    </table>
+                <?php endif; ?>
+                <?php if (isset($test_results['moreinfo_url']) && $test_results['moreinfo_url']) : ?>
+			<div class="moreinfo">
+				<a href="<?php echo $test_results['moreinfo_url']; ?>"
+					target="_blank"><?php
+                // Affiche "More information &raquo;"
+                switch (PHPSECINFO_LANG_DEFAULT) {
+                    case 'fr':
+                        echo 'Plus d\'information &raquo;';
+                        break;
 
-                        <?php if (isset($test_results['value_current']) || isset($test_results['value_recommended'])) :
-                            ?>
-                            <table class="values">
-                                <?php if (isset($test_results['value_current'])) :
-                                    ?>
-                                    <tr>
-                                        <td class="label"><?php
-                                            // Affiche "Current Value"
-                                            switch (PHPSECINFO_LANG_DEFAULT) {
-                                                case 'fr':
-                                                    echo 'Valeur actuelle';
+                    default:
+                        echo 'More information &raquo;';
+                        break;
+                }
+                ?></a>
+			</div>
+                <?php endif; ?>
+            </td>
+	</tr>
 
-                                                    break;
-                                                default:
-                                                    echo 'Current Value';
-
-                                                    break;
-                                            } ?></td>
-
-                                        <!-- <td><?php echo $test_results['value_current'] ?></td>  -->
-                                        <!-- https://github.com/bigdeej/PhpSecInfo/tree/master/PhpSecInfo/Test/Core -->
-                                        <td><?php echo wordwrap($test_results['value_current'], 55, '<br />', true) ?></td>
-                                    </tr>
-                                <?php endif; ?>
-                                <?php if (isset($test_results['value_recommended'])) :
-                                    ?>
-                                    <tr>
-                                        <td class="label"><?php
-                                            // Affiche "Recommended Value"
-                                            switch (PHPSECINFO_LANG_DEFAULT) {
-                                                case 'fr':
-                                                    echo 'Valeur recommandée';
-
-                                                    break;
-                                                default:
-                                                    echo 'Recommended Value';
-
-                                                    break;
-                                            } ?></td>
-                                        <td><?php echo $test_results['value_recommended'] ?></td>
-                                    </tr>
-                                <?php endif; ?>
-                            </table>
-                        <?php endif; ?>
-                        <?php if (isset($test_results['moreinfo_url']) && $test_results['moreinfo_url']) :
-                            ?>
-                            <div class="moreinfo">
-                                <a href="<?php echo $test_results['moreinfo_url']; ?>"
-                                   target="_blank"><?php
-                                    // Affiche "More information &raquo;"
-                                    switch (PHPSECINFO_LANG_DEFAULT) {
-                                        case 'fr':
-                                            echo 'Plus d\'information &raquo;';
-
-                                            break;
-                                        default:
-                                            echo 'More information &raquo;';
-
-                                            break;
-                                    } ?></a>
-                            </div>
-                        <?php endif; ?>
-                    </td>
-                </tr>
-
-            <?php endforeach; ?>
+        <?php endforeach; ?>
         </table>
-        <br/>
+<br />
 
-        <?php
+<?php
         return true;
     }
 
@@ -711,29 +692,29 @@ class PhpSecInfo
      * @see PHPSecInfo::_outputRenderTable()
      * @see PHPSecInfo::_outputGetResultTypeFromCode()
      */
-    public function _outputRenderStatsTable()
+    function _outputRenderStatsTable()
     {
         // Add by
         // https://github.com/bigdeej/PhpSecInfo/tree/master/PhpSecInfo/Test/Core
         $score = 100;
 
         foreach ($this->result_counts as $code => $val) {
-            if (PHPSECINFO_TEST_RESULT_NOTRUN != $code) {
+            if ($code != PHPSECINFO_TEST_RESULT_NOTRUN) {
                 $percentage = round($val / $this->num_tests_run * 100, 2);
 
                 // Add by
                 // https://github.com/bigdeej/PhpSecInfo/tree/master/PhpSecInfo/Test/Core
-                if (PHPSECINFO_TEST_RESULT_NOTICE == $code) {
+                if ($code == PHPSECINFO_TEST_RESULT_NOTICE) {
                     $score -= $percentage / 2;
-                } elseif (PHPSECINFO_TEST_RESULT_WARN == $code) {
+                } else if ($code == PHPSECINFO_TEST_RESULT_WARN) {
                     $score -= $percentage;
                 }
 
-                $stats[$this->_outputGetResultTypeFromCode($code)] = [
-                    'count'   => $val,
-                    'result'  => $code,
-                    'message' => "$val out of {$this->num_tests_run} ($percentage%)",
-                ];
+                $stats[$this->_outputGetResultTypeFromCode($code)] = array(
+                    'count' => $val,
+                    'result' => $code,
+                    'message' => "$val out of {$this->num_tests_run} ($percentage%)"
+                );
             }
         }
 
@@ -745,7 +726,7 @@ class PhpSecInfo
      *
      * @see PHPSecInfo::_outputRenderTable()
      */
-    public function _outputRenderNotRunTable()
+    function _outputRenderNotRunTable()
     {
         $this->_outputRenderTable('Tests Not Run', $this->tests_not_run);
     }
@@ -755,24 +736,35 @@ class PhpSecInfo
      * the result code the test returned.
      * This allows us to color-code results
      *
-     * @param int $code
+     * @param integer $code
      * @return string
      */
-    public function _outputGetCssClassFromResult($code)
+    function _outputGetCssClassFromResult($code)
     {
         switch ($code) {
             case PHPSECINFO_TEST_RESULT_OK:
                 return 'value-ok';
+                break;
+
             case PHPSECINFO_TEST_RESULT_NOTICE:
                 return 'value-notice';
+                break;
+
             case PHPSECINFO_TEST_RESULT_WARN:
                 return 'value-warn';
+                break;
+
             case PHPSECINFO_TEST_RESULT_NOTRUN:
                 return 'value-notrun';
+                break;
+
             case PHPSECINFO_TEST_RESULT_ERROR:
                 return 'value-error';
+                break;
+
             default:
                 return 'value-notrun';
+                break;
         }
     }
 
@@ -782,25 +774,36 @@ class PhpSecInfo
      * This is mainly used for the Test
      * Results Summary table.
      *
-     * @param int $code
-     * @return string
      * @see PHPSecInfo::_outputRenderStatsTable()
+     * @param integer $code
+     * @return string
      */
-    public function _outputGetResultTypeFromCode($code)
+    function _outputGetResultTypeFromCode($code)
     {
         switch ($code) {
             case PHPSECINFO_TEST_RESULT_OK:
                 return 'Pass';
+                break;
+
             case PHPSECINFO_TEST_RESULT_NOTICE:
                 return 'Notice';
+                break;
+
             case PHPSECINFO_TEST_RESULT_WARN:
                 return 'Warning';
+                break;
+
             case PHPSECINFO_TEST_RESULT_NOTRUN:
                 return 'Not Run';
+                break;
+
             case PHPSECINFO_TEST_RESULT_ERROR:
                 return 'Error';
+                break;
+
             default:
                 return 'Invalid Result Code';
+                break;
         }
     }
 
@@ -810,10 +813,9 @@ class PhpSecInfo
      *
      * @since 0.1.1
      */
-    public function loadAndRun()
+    function loadAndRun()
     {
         $this->loadTests();
-
         $this->runTests();
     }
 
@@ -829,16 +831,13 @@ class PhpSecInfo
      *
      * @return array
      */
-    public function getResultsAsArray()
+    function getResultsAsArray()
     {
-        $results = [];
+        $results = array();
 
         $results['test_results'] = $this->test_results;
-
         $results['tests_not_run'] = $this->tests_not_run;
-
         $results['result_counts'] = $this->result_counts;
-
         $results['num_tests_run'] = $this->num_tests_run;
 
         return $results;
@@ -850,13 +849,12 @@ class PhpSecInfo
      *
      * @return string
      */
-    public function getOutput()
+    function getOutput()
     {
         ob_start();
-
         $this->renderOutput();
-
-        return ob_get_clean();
+        $output = ob_get_clean();
+        return $output;
     }
 }
 
@@ -867,8 +865,6 @@ function phpsecinfo()
 {
     // modded this to not throw a PHP5 STRICT notice, although I don't like passing by value here
     $psi = new PhpSecInfo();
-
     $psi->loadAndRun();
-
     $psi->renderOutput();
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/CGI/force_redirect.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/CGI/force_redirect.php
@@ -1,42 +1,40 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for cgi force_redirect
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Cgi class
  */
-require_once dirname(__DIR__) . '/Test_Cgi.php';
+require_once('PhpSecInfo/Test/Test_Cgi.php');
 
 /**
  * Test class for cgi force_redirect
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 class PhpSecInfo_Test_Cgi_Force_Redirect extends PhpSecInfo_Test_Cgi
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'force_redirect';
+    public $test_name = "force_redirect";
 
     /**
      * The recommended setting value
      *
      * @public mixed
      */
-
     public $recommended_value = true;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('cgi.force_redirect');
     }
@@ -44,7 +42,7 @@ class PhpSecInfo_Test_Cgi_Force_Redirect extends PhpSecInfo_Test_Cgi
     /**
      * Checks to see if cgi.force_redirect is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -56,12 +54,10 @@ class PhpSecInfo_Test_Cgi_Force_Redirect extends PhpSecInfo_Test_Cgi
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'force_redirect is enabled, which is the recommended setting');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'force_redirect is disabled.  In most cases, this is a <strong>serious</strong> security vulnerability. Unless you are absolutely sure this is not needed, enable this setting');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "force_redirect is enabled, which is the recommended setting");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "force_redirect is disabled.  In most cases, this is a <strong>serious</strong> security vulnerability. Unless you are absolutely sure this is not needed, enable this setting");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/allow_url_fopen.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/allow_url_fopen.php
@@ -1,41 +1,39 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for allow_url_fopen
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once ('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for allow_url_fopen
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Allow_Url_Fopen extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'allow_url_fopen';
+    public $test_name = "allow_url_fopen";
 
     /**
      * The recommended setting value
      *
      * @public mixed
      */
-
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('allow_url_fopen');
     }
@@ -43,25 +41,21 @@ class PhpSecInfo_Test_Core_Allow_Url_Fopen extends PhpSecInfo_Test_Core
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'allow_url_fopen is disabled, which is the recommended setting');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'allow_url_fopen is enabled.  This could be a serious security risk.  You should disable allow_url_fopen and consider using the <a href="http://php.net/manual/en/ref.curl.php" target="_blank">PHP cURL functions</a> instead.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'allow_url_fopen is enabled.  This could be a serious security risk.  You should disable allow_url_fopen and consider using the <a href="http://php.net/manual/en/ref.curl.php" target="_blank">PHP cURL functions</a> instead.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/allow_url_include.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/allow_url_include.php
@@ -1,21 +1,20 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for allow_url_include
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for allow_url_include
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Allow_Url_Include extends PhpSecInfo_Test_Core
 {
@@ -24,12 +23,10 @@ class PhpSecInfo_Test_Core_Allow_Url_Include extends PhpSecInfo_Test_Core
      *
      * @public string
      */
-
-    public $test_name = 'allow_url_include';
-
+    public $test_name = "allow_url_include";
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('allow_url_include');
     }
@@ -37,41 +34,37 @@ class PhpSecInfo_Test_Core_Allow_Url_Include extends PhpSecInfo_Test_Core
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * allow_url_include is only available since PHP 5.2
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
-        if (PHP_VERSION_ID < 50200) {
-            return false;
-        }
 
-        return true;
+        if (version_compare(PHP_VERSION, '5.2', '<')) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'You are running a version of PHP older than 5.2, and allow_url_include is not available');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'allow_url_include is disabled, which is the recommended setting');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'allow_url_include is enabled.  This could be a serious security risk.  You should disable allow_url_include and consider using the <a href="http://php.net/manual/en/ref.curl.php" target="_blank">PHP cURL functions</a> instead.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'allow_url_include is enabled.  This could be a serious security risk.  You should disable allow_url_include and consider using the <a href="http://php.net/manual/en/ref.curl.php" target="_blank">PHP cURL functions</a> instead.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/display_errors.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/display_errors.php
@@ -1,35 +1,34 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for display_errors
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test class for display_errors
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Display_Errors extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'display_errors';
+    public $test_name = "display_errors";
 
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('display_errors');
     }
@@ -37,24 +36,21 @@ class PhpSecInfo_Test_Core_Display_Errors extends PhpSecInfo_Test_Core
     /**
      * Checks to see if display_errors is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'display_errors is disabled, which is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'display_errors is enabled.  This is not recommended on "production" servers, as it could reveal sensitive information.  You should consider disabling this feature');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/expose_php.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/expose_php.php
@@ -1,21 +1,21 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for expose_php
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
+
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test class for expose_php
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Expose_Php extends PhpSecInfo_Test_Core
 {
@@ -24,37 +24,32 @@ class PhpSecInfo_Test_Core_Expose_Php extends PhpSecInfo_Test_Core
      *
      * @public string
      */
-
-    public $test_name = 'expose_php';
-
+    public $test_name = "expose_php";
     public $recommended_value = false;
-
-    public function _retrieveCurrentValue()
+    
+    function _retrieveCurrentValue()
     {
-        $this->current_value = $this->returnBytes(ini_get('expose_php'));
+        $this->current_value =  $this->returnBytes(ini_get('expose_php'));
     }
-
+                    
     /**
      * Checks to see if expose_php is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
-
+        
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'expose_php is disabled, which is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'expose_php is enabled.  This adds
 				the PHP "signature" to the web server header, including the PHP version number.  This
 				could attract attackers looking for vulnerable versions of PHP');

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/file_uploads.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/file_uploads.php
@@ -1,35 +1,34 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for file_uploads
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for file_uploads
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_File_Uploads extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'file_uploads';
+    public $test_name = "file_uploads";
 
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->returnBytes(ini_get('file_uploads'));
     }
@@ -37,24 +36,21 @@ class PhpSecInfo_Test_Core_File_Uploads extends PhpSecInfo_Test_Core
     /**
      * Checks to see if expose_php is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'file_uploads are disabled.  Unless you\'re sure you need them, this is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'file_uploads are enabled.  If you do not require file upload capability, consider disabling them.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/gid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/gid.php
@@ -1,17 +1,14 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for GID
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * the minimum "safe" UID that php should be executing as.
@@ -22,46 +19,42 @@ define('PHPSECINFO_MIN_SAFE_GID', 100);
 
 /**
  * Test class for GID
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Gid extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'group_id';
+    public $test_name = "group_id";
 
     public $recommended_value = PHPSECINFO_MIN_SAFE_GID;
 
     /**
      * This test only works under Unix OSes
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         if ($this->osIsWindows()) {
             return false;
-        }
-
-        if (false === $this->getUnixId()) {
+        } elseif ($this->getUnixId() === false) {
             $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'Functions required to retrieve group ID not available');
-
             return false;
         }
-
         return true;
     }
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $id = $this->getUnixId();
-
         if (is_array($id)) {
             $lowest_gid = key($id['groups']);
-
             $this->current_value = $lowest_gid;
         } else {
             $this->current_value = false;
@@ -73,7 +66,7 @@ class PhpSecInfo_Test_Core_Gid extends PhpSecInfo_Test_Core
      *
      * @see PHPSECINFO_MIN_SAFE_GID
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value >= $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -85,14 +78,11 @@ class PhpSecInfo_Test_Core_Gid extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'PHP is executing as what is probably a non-privileged group');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'PHP may be executing as a "privileged" group, which could be a serious security vulnerability.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'This test will not run on Windows OSes');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/magic_quotes_gpc.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/magic_quotes_gpc.php
@@ -1,35 +1,34 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for magic_quotes_gpc
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for magic_quotes_gpc
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Magic_Quotes_GPC extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'magic_quotes_gpc';
+    public $test_name = "magic_quotes_gpc";
 
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('magic_quotes_gpc');
     }
@@ -37,17 +36,17 @@ class PhpSecInfo_Test_Core_Magic_Quotes_GPC extends PhpSecInfo_Test_Core
     /**
      * magic_quotes_gpc has been removed since PHP 6.0
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
-        return PHP_VERSION_ID < 60000;
+        return version_compare(PHP_VERSION, '6', '<');
     }
 
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -59,14 +58,11 @@ class PhpSecInfo_Test_Core_Magic_Quotes_GPC extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'You are running PHP 6 or later and magic_quotes_gpc has been removed');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'magic_quotes_gpc is disabled, which is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'magic_quotes_gpc is enabled.  This
 				feature is inconsistent in blocking attacks, and can in some cases cause data loss with
 				uploaded files.  You should <i>not</i> rely on magic_quotes_gpc to block attacks.  It is

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/memory_limit.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/memory_limit.php
@@ -1,10 +1,8 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for memory_limit setting
  *
+ * @package PhpSecInfo
  * @author  Paul Reinheimer
  * @author  Ed Finkler
  * @author  Mark Wallaert <mark@autumnweave.com>
@@ -13,8 +11,7 @@ declare(strict_types=1);
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * The max recommended size for the memory_limit setting, in bytes (8388608)
@@ -23,20 +20,22 @@ define('PHPSECINFO_MEMORY_LIMIT', 8 * 1024 * 1024);
 
 /**
  * Test Class for memory_limit setting
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Memory_Limit extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'memory_limit';
+    public $test_name = "memory_limit";
 
     public $recommended_value = PHPSECINFO_MEMORY_LIMIT;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->returnBytes(ini_get('memory_limit'));
     }
@@ -49,36 +48,33 @@ class PhpSecInfo_Test_Core_Memory_Limit extends PhpSecInfo_Test_Core
      * NOTICE: memory_limit enabled and set to a value greater than 8MB.
      * WARNING: memory_limit disabled (compile time option).
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
-        if (!$this->current_value) {
+        if (! $this->current_value) {
             return PHPSECINFO_TEST_RESULT_WARN;
-        }
-
-        if ($this->returnBytes($this->current_value) <= PHPSECINFO_MEMORY_LIMIT) {
+        } elseif ($this->returnBytes($this->current_value) <= PHPSECINFO_MEMORY_LIMIT) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
-
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
 
     /**
      * Set the messages specific to this test
+     *
+     * @access public
+     * @return null
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'memory_limit is enabled, and appears to be set
 				to a realistic value.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'memory_limit is set to a very high value. Are
 				you sure your apps require this much memory? If not, lower the limit, as certain attacks or poor
 				programming practices can lead to exhaustion of server resources. It is recommended that you set this
 				to a realistic value (8M for example) from which it can be expanded as required.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'memory_limit does not appear to be enabled.  This
 				leaves the server vulnerable to attacks that attempt to exhaust resources and creates an environment
 				where poor programming practices can propagate unchecked.  This must be enabled at compile time by

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/open_basedir.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/open_basedir.php
@@ -1,35 +1,34 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for open_basedir
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for open_basedir
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Open_Basedir extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'open_basedir';
+    public $test_name = "open_basedir";
 
     public $recommended_value = true;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('open_basedir');
     }
@@ -37,7 +36,7 @@ class PhpSecInfo_Test_Core_Open_Basedir extends PhpSecInfo_Test_Core
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -49,14 +48,12 @@ class PhpSecInfo_Test_Core_Open_Basedir extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'open_basedir is enabled, which is the
 				recommended setting. Keep in mind that other web applications not written in PHP will not
 				be restricted by this setting.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'open_basedir is disabled.  When
 					this is enabled, only files that are in the
 					given directory/directories and their subdirectories can be read by PHP scripts.

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/post_max_size.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/post_max_size.php
@@ -1,52 +1,52 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for post_max_size
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * The max recommended size for the post_max_size setting, in bytes (33554432)
  */
-define('PHPSECINFO_POST_MAXLIMIT', 32 * 1024 * 1024);
+define('PHPSECINFO_POST_MAXLIMIT', 32*1024*1024);
 
 /**
  * Test Class for post_max_size
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Post_Max_Size extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'post_max_size';
+    public $test_name = "post_max_size";
 
     public $recommended_value = PHPSECINFO_POST_MAXLIMIT;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
-        $this->current_value = $this->returnBytes(ini_get('post_max_size'));
+        $this->current_value =  $this->returnBytes(ini_get('post_max_size'));
     }
 
     /**
      * Check to see if the post_max_size setting is enabled.
      */
-    public function _execTest()
+    function _execTest()
     {
+
         if ($this->current_value
             && $this->current_value <= $this->recommended_value
-            && -1 != $post_max_size) {
+            && $post_max_size != -1) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
 
@@ -55,14 +55,14 @@ class PhpSecInfo_Test_Core_Post_Max_Size extends PhpSecInfo_Test_Core
 
     /**
      * Set the messages specific to this test
+     *
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
 
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'post_max_size is enabled, and appears to
 				be a relatively low value');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'post_max_size is not enabled, or is set to
 				a high value. Allowing a large value may open up your server to denial-of-service attacks');
     }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/register_globals.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/register_globals.php
@@ -1,21 +1,20 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for register_globals
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for register_globals
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Register_Globals extends PhpSecInfo_Test_Core
 {
@@ -24,12 +23,10 @@ class PhpSecInfo_Test_Core_Register_Globals extends PhpSecInfo_Test_Core
      *
      * @public string
      */
-
-    public $test_name = 'register_globals';
-
+    public $test_name = "register_globals";
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('register_globals');
     }
@@ -37,17 +34,17 @@ class PhpSecInfo_Test_Core_Register_Globals extends PhpSecInfo_Test_Core
     /**
      * register_globals has been removed since PHP 6.0
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
-        return PHP_VERSION_ID < 60000;
+        return version_compare(PHP_VERSION, '6', '<') ;
     }
 
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -59,14 +56,11 @@ class PhpSecInfo_Test_Core_Register_Globals extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'You are running PHP 6 or later and register_globals has been removed');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'register_globals is disabled, which is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'register_globals is enabled.  This could be a serious security risk.  You should disable register_globals immediately');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/uid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/uid.php
@@ -1,64 +1,58 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for UID
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * the minimum "safe" UID that php should be executing as.  This can vary,
  * but in general 100 seems like a good min.
+ *
  */
 define('PHPSECINFO_MIN_SAFE_UID', 100);
 
 /**
  * Test class for UID
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Uid extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'user_id';
-
+    public $test_name = "user_id";
     public $recommended_value = PHPSECINFO_MIN_SAFE_UID;
 
     /**
      * This test only works under Unix OSes
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         if ($this->osIsWindows()) {
             return false;
-        }
-
-        if (false === $this->getUnixId()) {
+        } elseif ($this->getUnixId() === false) {
             $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'Functions required to retrieve user ID not available');
-
             return false;
         }
-
         return true;
     }
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $id = $this->getUnixId();
-
         if (is_array($id)) {
             $this->current_value = $id['uid'];
         } else {
@@ -71,7 +65,7 @@ class PhpSecInfo_Test_Core_Uid extends PhpSecInfo_Test_Core
      *
      * @see PHPSECINFO_MIN_SAFE_UID
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value >= $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -83,14 +77,11 @@ class PhpSecInfo_Test_Core_Uid extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'PHP is executing as what is probably a non-privileged user');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'PHP may be executing as a "privileged" user, which could be a serious security vulnerability.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'This test will not run on Windows OSes');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/upload_max_filesize.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/upload_max_filesize.php
@@ -1,39 +1,39 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for upload_max_filesize
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once('PhpSecInfo/Test/Test_Core.php');
+
 /**
  * The max recommended size for the upload_max_filesize setting, in bytes (33554432)
  */
-define('PHPSECINFO_UPLOAD_MAXLIMIT', 32 * 1024 * 1024);
+define('PHPSECINFO_UPLOAD_MAXLIMIT', 32*1024*1024);
 
 /**
  * Test Class for upload_max_filesize
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Upload_Max_Filesize extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'upload_max_filesize';
+    public $test_name = "upload_max_filesize";
 
     public $recommended_value = PHPSECINFO_UPLOAD_MAXLIMIT;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->returnBytes(ini_get('upload_max_filesize'));
     }
@@ -41,9 +41,9 @@ class PhpSecInfo_Test_Core_Upload_Max_Filesize extends PhpSecInfo_Test_Core
     /**
      * Check to see if the post_max_size setting is enabled.
      */
-    public function _execTest()
+    function _execTest()
     {
-        if ($this->current_value && $this->current_value <= $this->recommended_value && -1 != $post_max_size) {
+        if ($this->current_value && $this->current_value <= $this->recommended_value && $post_max_size != - 1) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
 
@@ -53,13 +53,11 @@ class PhpSecInfo_Test_Core_Upload_Max_Filesize extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
 
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'upload_max_filesize is enabled, and appears to be a relatively low value.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'upload_max_filesize is not enabled, or is set to a high value.  Are you sure your apps require uploading files of this size?  If not, lower the limit, as large file uploads can impact server performance');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'upload_max_filesize is not enabled, or is set to a high value.  Are you sure your apps require uploading files of this size?  If not, lower the limit, as large file uploads can impact server performance');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/upload_tmp_dir.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/upload_tmp_dir.php
@@ -1,39 +1,38 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test Class for upload_tmp_dir
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test Class for upload_tmp_dir
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
+    public $test_name = "upload_tmp_dir";
 
-    public $test_name = 'upload_tmp_dir';
+    public $recommended_value = "A non-world readable/writable directory";
 
-    public $recommended_value = 'A non-world readable/writable directory';
-
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = ini_get('upload_tmp_dir');
 
         if (empty($this->current_value)) {
-            if (function_exists('sys_get_temp_dir')) {
+            if (function_exists("sys_get_temp_dir")) {
                 $this->current_value = sys_get_temp_dir();
             } else {
                 $this->current_value = $this->sys_get_temp_dir();
@@ -45,15 +44,15 @@ class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
      * We are disabling this function on Windows OSes right now until
      * we can be certain of the proper way to check world-readability
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         if ($this->osIsWindows()) {
             return false;
+        } else {
+            return true;
         }
-
-        return true;
     }
 
     /**
@@ -65,24 +64,19 @@ class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
      *
      * @see PHPSECINFO_TEST_COMMON_TMPDIR
      */
-    public function _execTest()
+    function _execTest()
     {
         $perms = @fileperms($this->current_value);
-
-        if (false === $perms) {
+        if ($perms === false) {
             return PHPSECINFO_TEST_RESULT_WARN;
-        }
-
-        if ($this->current_value
+        } elseif ($this->current_value
             /* && !preg_match("|" . PHPSECINFO_TEST_COMMON_TMPDIR . "/?|", $this->current_value) */
-            && !preg_match('%^' . PHPSECINFO_TEST_COMMON_TMPDIR . '(/|$)%', $this->current_value)
-            && !($perms & 0x0004)
-            && !($perms & 0x0002)) {
+            && ! preg_match("%^" . PHPSECINFO_TEST_COMMON_TMPDIR . "(/|$)%", $this->current_value) && ! ($perms & 0x0004) && ! ($perms & 0x0002)) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
 
         // Rewrite current_value to display perms
-        $this->current_value .= ' (' . mb_substr(sprintf('%o', $perms), -4) . ')';
+        $this->current_value .= " (" . substr(sprintf('%o', $perms), - 4) . ")";
 
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
@@ -90,16 +84,12 @@ class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'Test not run -- currently disabled on Windows OSes');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'upload_tmp_dir is enabled, which is the recommended setting.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'Unable to retrieve file permissions on upload_tmp_dir');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'upload_tmp_dir is disabled, or you use the /tmp directory but
                                                 this naming is not allowed for this test and you must provide a custom directory, or is set
                                                 to a common world-writable directory (xx5). This typically allows other users on this server

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/version.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Core/version.php
@@ -1,47 +1,44 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for PHP Version
  * Test from : https://github.com/bigdeej/PhpSecInfo/blob/master/PhpSecInfo/Test/Core/version.php
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Curl class
  */
-//require_once('PhpSecInfo/Test/Test_Core.php');
-require_once dirname(__DIR__) . '/Test_Core.php';
+require_once ('PhpSecInfo/Test/Test_Core.php');
 
 /**
  * Test class for PHP Version
  * Checks the current PHP Version against EOL Versions.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Core_Version extends PhpSecInfo_Test_Core
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'version_number';
+    public $test_name = "version_number";
 
     // Cette ligne ne semble pas influencer la version recommandée qui est gérée depuis le fichier .version.json directement.
     public $recommended_value = '7.3.0';
 
     public $last_eol_value = '5.6.15';
 
-    private $_message_ok = 'You are running a current stable version of PHP!';
+    private $_message_ok = "You are running a current stable version of PHP!";
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = PHP_VERSION;
-
         // $this->current_value = '5.4.15';
     }
 
@@ -54,34 +51,29 @@ class PhpSecInfo_Test_Core_Version extends PhpSecInfo_Test_Core
      */
     public function _retrieveCurrentVersions()
     {
-        if (!function_exists('curl_init')) {
+        if (! function_exists('curl_init')) {
             // Override the OK Message - Even if this passes we can't be 100% sure they are accurate since we didn't fetch the latest version
-            $this->_message_ok = 'You are running a current stable version of PHP!
+            $this->_message_ok = "You are running a current stable version of PHP!
 						<br /><strong>NOTE:</strong> CURL was unable to fetch the latest PHP Versions from the internet. This test may not be accurate if
-						PhpSecInfo is not up to date.';
+						PhpSecInfo is not up to date.";
 
-            return [
+            return array(
                 'stable' => $this->recommended_value,
-                'eol'    => $this->last_eol_value,
-            ];
+                'eol' => $this->last_eol_value
+            );
         }
 
         // Attempt to fetch from server
         // Récupérer la version de PHP depuis le fichier .version.json
         $uri = 'https://raw.githubusercontent.com/ZerooCool/phpsecinfo/phpsecinfo-zeroocool-v0.2.1/20070406-phpsecinfo-v0.2.1/.version.json';
-
         $ch = curl_init();
-
         $timeout = 5;
 
         // CURL
         curl_setopt($ch, CURLOPT_URL, $uri);
-
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-
         // curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
         $data = curl_exec($ch);
-
         // Close CURL
         curl_close($ch);
 
@@ -89,23 +81,23 @@ class PhpSecInfo_Test_Core_Version extends PhpSecInfo_Test_Core
         $json = json_decode($data);
 
         // Detect CURL error and return local value
-        if (false === $data || !isset($json->stable) || !isset($json->eol)) {
+        if ($data === false || ! isset($json->stable) || ! isset($json->eol)) {
             // Override the OK Message - Even if this passes we can't be 100% sure they are accurate since we didn't fetch the latest version
-            $this->_message_ok = 'You are running a current stable version of PHP!
+            $this->_message_ok = "You are running a current stable version of PHP!
 						<br /><strong>NOTE:</strong> CURL was unable to fetch the latest PHP Versions from the internet. This test may not be accurate if
-						PhpSecInfo is not up to date.';
+						PhpSecInfo is not up to date.";
 
-            return [
+            return array(
                 'stable' => $this->recommended_value,
-                'eol'    => $this->last_eol_value,
-            ];
+                'eol' => $this->last_eol_value
+            );
         }
 
         // to array
-        $versions = [
+        $versions = array(
             'stable' => $json->stable,
-            'eol'    => $json->eol,
-        ];
+            'eol' => $json->eol
+        );
 
         // Update local recommended value (it is used elsewhere and we don't want to modify that code just yet)
         // Mettre à jour la valeur recommandée locale (elle est utilisée ailleurs et nous ne voulons pas modifier ce code pour l'instant)
@@ -117,28 +109,26 @@ class PhpSecInfo_Test_Core_Version extends PhpSecInfo_Test_Core
     /**
      * Checks to see if the current PHP version is acceptable
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Get versions
         $version = $this->_retrieveCurrentVersions();
 
         if (version_compare($this->current_value, $version['stable'], '>=')) {
             return PHPSECINFO_TEST_RESULT_OK;
-        }
-
-        if (version_compare($this->current_value, $version['stable'], '<') && version_compare($this->current_value, $version['eol'], '>')) {
+        } else if (version_compare($this->current_value, $version['stable'], '<') && version_compare($this->current_value, $version['eol'], '>')) {
             return PHPSECINFO_TEST_RESULT_NOTICE;
+        } else {
+            return PHPSECINFO_TEST_RESULT_WARN;
         }
-
-        return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
 
@@ -146,10 +136,7 @@ class PhpSecInfo_Test_Core_Version extends PhpSecInfo_Test_Core
         $this->_retrieveCurrentVersions();
 
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', $this->_message_ok);
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'You are running a version of PHP that has reached End of Life for support.  You should upgrade to the latest version of PHP immediately.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'You are running a version of PHP that is not the most recent and may be near End of Life for support.  You should begin to migrate to the latest version of PHP as soon as possible.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "You are running a version of PHP that has reached End of Life for support.  You should upgrade to the latest version of PHP immediately.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'You are running a version of PHP that is not the most recent and may be near End of Life for support.  You should begin to migrate to the latest version of PHP as soon as possible.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Curl/file_support.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Curl/file_support.php
@@ -1,18 +1,15 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for CURL file_support
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Curl class
  */
-//require_once('PhpSecInfo/Test/Test_Curl.php');
-require_once dirname(__DIR__) . '/Test_Curl.php';
+require_once('PhpSecInfo/Test/Test_Curl.php');
 
 /**
  * Test class for CURL file_support
@@ -20,58 +17,58 @@ require_once dirname(__DIR__) . '/Test_Curl.php';
  * Checks for CURL file:// support; if this is installed, it can be used to bypass
  * safe_mode and open_basedir
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 class PhpSecInfo_Test_Curl_File_Support extends PhpSecInfo_Test_Curl
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'file_support';
+    public $test_name = "file_support";
 
     public $recommended_value = '5.1.6+ or 4.4.4+';
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = PHP_VERSION;
     }
+    
 
     /**
      * Checks to see if libcurl's "file://" support is enabled by examining the "protocols" array
      * in the info returned from curl_version()
-     * @return int
+     * @return integer
+     *
      */
-    public function _execTest()
+    function _execTest()
     {
+
         $curlinfo = curl_version();
 
-        if (version_compare($this->current_value, '5.1.6', '>=')
-            || (version_compare($this->current_value, '4.4.4', '>=')) && (version_compare($this->current_value, '5', '<'))) {
+        if (version_compare($this->current_value, '5.1.6', '>=') ||
+            (version_compare($this->current_value, '4.4.4', '>=')) && ( version_compare($this->current_value, '5', '<') )
+            ) {
             return PHPSECINFO_TEST_RESULT_OK;
+        } else {
+            return PHPSECINFO_TEST_RESULT_WARN;
         }
-
-        return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
+     *
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en',
-                                   'You are running PHP 4.4.4 or higher, or PHP 5.1.6 or higher.  These versions fix the security hole present in the cURL functions that allow it to bypass safe_mode and open_basedir restrictions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'A security hole present in your version of PHP allows the cURL functions to bypass safe_mode and open_basedir restrictions. You should upgrade to the latest version of PHP.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'fr',
-                                   'Vous utilisez PHP 4.4.4 ou supérieur, ou PHP 5.1.6 ou supérieur. Ces versions corrigent les failles de sécurité présentes dans les fonctions cURL qui lui permettent de contourner les restrictions safe_mode et open_basedir.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'fr',
-                                   'Une faille de sécurité présente dans votre version de PHP permet aux fonctions cURL de contourner les restrictions safe_mode et open_basedir. Vous devriez passer à la dernière version de PHP.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You are running PHP 4.4.4 or higher, or PHP 5.1.6 or higher.  These versions fix the security hole present in the cURL functions that allow it to bypass safe_mode and open_basedir restrictions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "A security hole present in your version of PHP allows the cURL functions to bypass safe_mode and open_basedir restrictions. You should upgrade to the latest version of PHP.");
+        
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'fr', "Vous utilisez PHP 4.4.4 ou supérieur, ou PHP 5.1.6 ou supérieur. Ces versions corrigent les failles de sécurité présentes dans les fonctions cURL qui lui permettent de contourner les restrictions safe_mode et open_basedir.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'fr', "Une faille de sécurité présente dans votre version de PHP permet aux fonctions cURL de contourner les restrictions safe_mode et open_basedir. Vous devriez passer à la dernière version de PHP.");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_dir_write.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_dir_write.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for is_self_write
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Dir class
  */
-//require_once ('PhpSecInfo/Test/Test_Dir.php');
-require_once dirname(__DIR__) . '/Test_Dir.php';
+require_once ('PhpSecInfo/Test/Test_Dir.php');
 
 /**
  * Test class for function is_self_write
  * Checks if file permissions are proper for security.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Dir_Is_Dir_Write extends PhpSecInfo_Test_Dir
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'is_dir_write';
+    public $test_name = "is_dir_write";
 
     public $recommended_value = 'Read-Only';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         // Get current permissions
         // if (is_executable('.')) { $this->current_value = 'Execute+Write+Read'; }
@@ -49,33 +49,28 @@ class PhpSecInfo_Test_Dir_Is_Dir_Write extends PhpSecInfo_Test_Dir
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check permissions
-        if ('Read-Only' == $this->current_value) {
+        if ($this->current_value == 'Read-Only') {
             return PHPSECINFO_TEST_RESULT_OK;
-        }
-
-        if ('Write+Read' == $this->current_value) {
+        } else if ($this->current_value == 'Write+Read') {
             return PHPSECINFO_TEST_RESULT_NOTICE;
+        } else {
+            return PHPSECINFO_TEST_RESULT_WARN;
         }
-
-        return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'Only allowing Read permission. This is the most secure setup.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'Execute permission enabled! You should never allow execution here.');
-
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "Only allowing Read permission. This is the most secure setup.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "Execute permission enabled! You should never allow execution here.");
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'Write permission enabled. You should consider revoking this permission since it can allow attackers to more easily modify files on your site.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_root_read.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_root_read.php
@@ -1,46 +1,46 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for is_root_read
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Dir class
  */
-//require_once ('PhpSecInfo/Test/Test_Dir.php');
-require_once dirname(__DIR__) . '/Test_Dir.php';
+require_once ('PhpSecInfo/Test/Test_Dir.php');
 
 /**
  * Test class for function is_self_write
  * Checks if file permissions are proper for security.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Dir_Is_Root_Read extends PhpSecInfo_Test_Dir
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'is_root_read';
+    public $test_name = "is_root_read";
 
     public $recommended_value = 'None';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         // Get current permissions
         if (is_writable('/')) {
             $this->current_value = 'Write+Read';
-        } elseif (is_readable('/')) {
+        } else if (is_readable('/')) {
             $this->current_value = 'Read-Only';
         } else {
             $this->current_value = 'None';
@@ -50,33 +50,28 @@ class PhpSecInfo_Test_Dir_Is_Root_Read extends PhpSecInfo_Test_Dir
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check permissions
-        if ('None' == $this->current_value) {
+        if ($this->current_value == 'None') {
             return PHPSECINFO_TEST_RESULT_OK;
-        }
-
-        if ('Read-Only' == $this->current_value) {
+        } else if ($this->current_value == 'Read-Only') {
             return PHPSECINFO_TEST_RESULT_NOTICE;
+        } else {
+            return PHPSECINFO_TEST_RESULT_WARN;
         }
-
-        return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "No permissions granted for the root ('/') directory. This is the most secure setup.");
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "Write permission enabled for the root ('/') directory! You should never allow writing outside your www base.");
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', "Read permission enabled. You should under normal instances never allow Reading of the root ('/').");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_self_write.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Dir/is_self_write.php
@@ -1,46 +1,46 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for is_self_write
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Dir class
  */
-//require_once ('PhpSecInfo/Test/Test_Dir.php');
-require_once dirname(__DIR__) . '/Test_Dir.php';
+require_once ('PhpSecInfo/Test/Test_Dir.php');
 
 /**
  * Test class for function is_self_write
  * Checks if file permissions are proper for security.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Dir_Is_Self_Write extends PhpSecInfo_Test_Dir
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'is_self_write';
+    public $test_name = "is_self_write";
 
     public $recommended_value = 'Read-Only';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         // Get current permissions
         if (is_executable(__FILE__)) {
             $this->current_value = 'Execute+Write+Read';
-        } elseif (is_writable(__FILE__)) {
+        } else if (is_writable(__FILE__)) {
             $this->current_value = 'Write+Read';
         } else {
             $this->current_value = 'Read-Only';
@@ -50,33 +50,28 @@ class PhpSecInfo_Test_Dir_Is_Self_Write extends PhpSecInfo_Test_Dir
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check permissions
-        if ('Read-Only' == $this->current_value) {
+        if ($this->current_value == 'Read-Only') {
             return PHPSECINFO_TEST_RESULT_OK;
-        }
-
-        if ('Write+Read' == $this->current_value) {
+        } else if ($this->current_value == 'Write+Read') {
             return PHPSECINFO_TEST_RESULT_NOTICE;
+        } else {
+            return PHPSECINFO_TEST_RESULT_WARN;
         }
-
-        return PHPSECINFO_TEST_RESULT_WARN;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'Only allowing Read permission. This is the most secure setup.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'Execute permission enabled! You should never allow execution here.');
-
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "Only allowing Read permission. This is the most secure setup.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "Execute permission enabled! You should never allow execution here.");
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'Write permission enabled. You should consider revoking this permission since it can allow attackers to more easily modify files on your site.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/apache_child_terminate.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/apache_child_terminate.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for apache_child_terminate
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function apache_child_terminate
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Apache_Child_Terminate extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'apache_child_terminate';
+    public $test_name = "apache_child_terminate";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Apache_Child_Terminate extends PhpSecInfo_Test_F
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/apache_setenv.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/apache_setenv.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for apache_setenv
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function apache_setenv
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Apache_Setenv extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'apache_setenv';
+    public $test_name = "apache_setenv";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,33 +47,28 @@ class PhpSecInfo_Test_Functions_Apache_Setenv extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
 
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'fr', 'Vous avez listé cette fonction dans votre php.ini sous disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'fr', "Vous avez listé cette fonction dans votre php.ini sous disabled_functions.");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/define_syslog_variables.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/define_syslog_variables.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for define_syslog_variables
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function define_syslog_variables
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Define_Syslog_Variables extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'define_syslog_variables';
+    public $test_name = "define_syslog_variables";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Define_Syslog_Variables extends PhpSecInfo_Test_
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/escapeshellarg.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/escapeshellarg.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for escapeshellarg
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function escapeshellarg
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Escapeshellarg extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'escapeshellarg';
+    public $test_name = "escapeshellarg";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Escapeshellarg extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/escapeshellcmd.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/escapeshellcmd.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for escapeshellcmd
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function escapeshellcmd
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Escapeshellcmd extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'escapeshellcmd';
+    public $test_name = "escapeshellcmd";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Escapeshellcmd extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/eval.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/eval.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for eval
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function eval
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Eval extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'eval';
+    public $test_name = "eval";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Eval extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/exec.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/exec.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for exec
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function exec
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Exec extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'exec';
+    public $test_name = "exec";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Exec extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/fp.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/fp.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for fp
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function fp
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Fp extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'fp';
+    public $test_name = "fp";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Fp extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/fput.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/fput.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for fput
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function fput
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Fput extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'fput';
+    public $test_name = "fput";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Fput extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_connect.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_connect.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_connect
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_connect
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Connect extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_connect';
+    public $test_name = "ftp_connect";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Connect extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_exec.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_exec.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_exec
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_exec
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Exec extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_exec';
+    public $test_name = "ftp_exec";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Exec extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_get.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_get.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_get
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_get
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Get extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_get';
+    public $test_name = "ftp_get";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Get extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_login.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_login.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_login
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_login
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Login extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_login';
+    public $test_name = "ftp_login";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Login extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_nb_fput.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_nb_fput.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_nb_fput
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_nb_fput
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Nb_Fput extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_nb_fput';
+    public $test_name = "ftp_nb_fput";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Nb_Fput extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_put.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_put.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_put
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_put
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Put extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_put';
+    public $test_name = "ftp_put";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Put extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_raw.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_raw.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_raw
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_raw
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Raw extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_raw';
+    public $test_name = "ftp_raw";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Raw extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_rawlist.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ftp_rawlist.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ftp_rawlist
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ftp_rawlist
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ftp_Rawlist extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ftp_rawlist';
+    public $test_name = "ftp_rawlist";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ftp_Rawlist extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/highlight_file.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/highlight_file.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for highlight_file
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function highlight_file
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Highlight_File extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'highlight_file';
+    public $test_name = "highlight_file";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Highlight_File extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_alter.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_alter.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ini_alter
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ini_alter
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ini_Alter extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ini_alter';
+    public $test_name = "ini_alter";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ini_Alter extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_get_all.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_get_all.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ini_get_all
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ini_get_all
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ini_Get_All extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ini_get_all';
+    public $test_name = "ini_get_all";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ini_Get_All extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_restore.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/ini_restore.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for ini_restore
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function ini_restore
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Ini_Restore extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'ini_restore';
+    public $test_name = "ini_restore";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Ini_Restore extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/inject_code.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/inject_code.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for inject_code
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function inject_code
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Inject_Code extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'inject_code';
+    public $test_name = "inject_code";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Inject_Code extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/mysql_pconnect.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/mysql_pconnect.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for mysql_pconnect
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function mysql_pconnect
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Mysql_Pconnect extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'mysql_pconnect';
+    public $test_name = "mysql_pconnect";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Mysql_Pconnect extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/openlog.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/openlog.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for openlog
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function openlog
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Openlog extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'openlog';
+    public $test_name = "openlog";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Openlog extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/passthru.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/passthru.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for passthru
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function passthru
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Passthru extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'passthru';
+    public $test_name = "passthru";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Passthru extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_XmlRpc.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_XmlRpc.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for phpAds_XmlRpc
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function phpAds_XmlRpc
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_PhpAds_XmlRpc extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'phpAds_XmlRpc';
+    public $test_name = "phpAds_XmlRpc";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_PhpAds_XmlRpc extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_remoteInfo.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_remoteInfo.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for phpAds_remoteInfo
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function phpAds_remoteInfo
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_PhpAds_RemoteInfo extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'phpAds_remoteInfo';
+    public $test_name = "phpAds_remoteInfo";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_PhpAds_RemoteInfo extends PhpSecInfo_Test_Functi
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_xmlrpcDecode.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_xmlrpcDecode.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for phpAds_xmlrpcDecode
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function phpAds_xmlrpcDecode
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_PhpAds_XmlrpcDecode extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'phpAds_xmlrpcDecode';
+    public $test_name = "phpAds_xmlrpcDecode";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_PhpAds_XmlrpcDecode extends PhpSecInfo_Test_Func
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_xmlrpcEncode.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/phpAds_xmlrpcEncode.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for phpAds_xmlrpcEncode
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function phpAds_xmlrpcEncode
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_PhpAds_XmlrpcEncode extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'phpAds_xmlrpcEncode';
+    public $test_name = "phpAds_xmlrpcEncode";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_PhpAds_XmlrpcEncode extends PhpSecInfo_Test_Func
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/php_uname.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/php_uname.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for php_uname
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function php_uname
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Php_Uname extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'php_uname';
+    public $test_name = "php_uname";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Php_Uname extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/popen.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/popen.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for popen
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function popen
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Popen extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'popen';
+    public $test_name = "popen";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Popen extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_getpwuid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_getpwuid.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_getpwuid
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_getpwuid
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Getpwuid extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_getpwuid';
+    public $test_name = "posix_getpwuid";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Getpwuid extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_kill.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_kill.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_kill
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_kill
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Kill extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_kill';
+    public $test_name = "posix_kill";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Kill extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_mkfifo.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_mkfifo.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_mkfifo
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_mkfifo
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Mkfifo extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_mkfifo';
+    public $test_name = "posix_mkfifo";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Mkfifo extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setpgid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setpgid.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_setpgid
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_setpgid
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Setpgid extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_setpgid';
+    public $test_name = "posix_setpgid";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Setpgid extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setsid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setsid.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_setsid
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_setsid
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Setsid extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_setsid';
+    public $test_name = "posix_setsid";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Setsid extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setuid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_setuid.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_setuid
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_setuid
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Setuid extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_setuid';
+    public $test_name = "posix_setuid";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Setuid extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_uname.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/posix_uname.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for posix_uname
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function posix_uname
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Posix_Uname extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'posix_uname';
+    public $test_name = "posix_uname";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Posix_Uname extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_close.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_close.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for proc_close
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function proc_close
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Proc_Close extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'proc_close';
+    public $test_name = "proc_close";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Proc_Close extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_get_status.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_get_status.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for proc_get_status
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function proc_get_status
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Proc_Get_Status extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'proc_get_status';
+    public $test_name = "proc_get_status";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Proc_Get_Status extends PhpSecInfo_Test_Function
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_nice.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_nice.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for proc_nice
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function proc_nice
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Proc_Nice extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'proc_nice';
+    public $test_name = "proc_nice";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Proc_Nice extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_open.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_open.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for proc_open
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function proc_open
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Proc_Open extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'proc_open';
+    public $test_name = "proc_open";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Proc_Open extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_terminate.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/proc_terminate.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for proc_terminate
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function proc_terminate
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Proc_Terminate extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'proc_terminate';
+    public $test_name = "proc_terminate";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Proc_Terminate extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/shell_exec.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/shell_exec.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for shell_exec
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function shell_exec
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Shell_Exec extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'shell_exec';
+    public $test_name = "shell_exec";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Shell_Exec extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/syslog.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/syslog.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for syslog
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function syslog
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Syslog extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'syslog';
+    public $test_name = "syslog";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Syslog extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/system.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/system.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for system
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function system
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_System extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'system';
+    public $test_name = "system";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_System extends PhpSecInfo_Test_Functions
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/xmlrpc_entity_decode.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Functions/xmlrpc_entity_decode.php
@@ -1,41 +1,41 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for xmlrpc_entity_decode
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Functions class
  */
-//require_once ('PhpSecInfo/Test/Test_Functions.php');
-require_once dirname(__DIR__) . '/Test_Functions.php';
+require_once ('PhpSecInfo/Test/Test_Functions.php');
 
 /**
  * Test class for function xmlrpc_entity_decode
  * Checks if dangerous functionality is enabled.
  *
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 class PhpSecInfo_Test_Functions_Xmlrpc_Entity_Decode extends PhpSecInfo_Test_Functions
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'xmlrpc_entity_decode';
+    public $test_name = "xmlrpc_entity_decode";
 
     public $recommended_value = 'Disabled';
 
     /**
      * Return the current value for this Test
+     *
+     * @return
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         if (function_exists($this->test_name)) {
             $this->current_value = 'Enabled';
@@ -47,31 +47,26 @@ class PhpSecInfo_Test_Functions_Xmlrpc_Entity_Decode extends PhpSecInfo_Test_Fun
     /**
      * Checks to see if the function is enabled
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         // Check if function exists
         if (function_exists($this->test_name)) {
             return PHPSECINFO_TEST_RESULT_WARN;
+        } else {
+            return PHPSECINFO_TEST_RESULT_OK;
         }
-
-        return PHPSECINFO_TEST_RESULT_OK;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'You have this function listed in your php.ini under disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.');
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en',
-                                   'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', "You have this function listed in your php.ini under disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', "This function is not in your php.ini disabled_functions and is enabled.  This function can cause serious security implications, unless you absolutely need this function you should add it to your disabled_functions.");
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This function is not in your php.ini disabled_functions and is enabled.  Use caution with this function and if you do not need it explicitly add it to your disabled_functions.');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Session/save_path.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Session/save_path.php
@@ -1,40 +1,39 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for session save_path
  *
+ * @package PhpSecInfo
  * @author Thomas CORBIERE <thomas@votre-grandeur-celeste.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Core class
  */
-//require_once ('PhpSecInfo/Test/Test_Session.php');
-require_once dirname(__DIR__) . '/Test_Session.php';
+require_once ('PhpSecInfo/Test/Test_Session.php');
 
 /**
  * Test class for session save_path
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Session_Save_Path extends PhpSecInfo_Test_Session
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
+    public $test_name = "save_path";
 
-    public $test_name = 'save_path';
+    public $recommended_value = "A non-world readable/writable directory (750 for example)";
 
-    public $recommended_value = 'A non-world readable/writable directory (750 for example)';
-
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = ini_get('session.save_path');
 
         if (empty($this->current_value)) {
-            if (function_exists('sys_get_temp_dir')) {
+            if (function_exists("sys_get_temp_dir")) {
                 $this->current_value = sys_get_temp_dir();
             } else {
                 $this->current_value = $this->sys_get_temp_dir();
@@ -46,15 +45,15 @@ class PhpSecInfo_Test_Session_Save_Path extends PhpSecInfo_Test_Session
      * We are disabling this function on Windows OSes right now until
      * we can be certain of the proper way to check world-readability
      *
-     * @return bool
+     * @return unknown
      */
-    public function isTestable()
+    function isTestable()
     {
         if ($this->osIsWindows()) {
             return false;
+        } else {
+            return true;
         }
-
-        return true;
     }
 
     /**
@@ -64,31 +63,26 @@ class PhpSecInfo_Test_Session_Save_Path extends PhpSecInfo_Test_Session
      *
      * @see PHPSECINFO_TEST_COMMON_TMPDIR
      */
-    public function _execTest()
+    function _execTest()
     {
         $perms = fileperms($this->current_value);
-
-        if ($this->current_value && !preg_match('|' . PHPSECINFO_TEST_COMMON_TMPDIR . '/?|', $this->current_value) && !($perms & 0x0004) && !($perms & 0x0002)) {
+        if ($this->current_value && ! preg_match("|" . PHPSECINFO_TEST_COMMON_TMPDIR . "/?|", $this->current_value) && ! ($perms & 0x0004) && ! ($perms & 0x0002)) {
             return PHPSECINFO_TEST_RESULT_OK;
         }
 
         // Rewrite current_value to display perms
-        $this->current_value .= ' (' . mb_substr(sprintf('%o', $perms), -4) . ')';
-
+        $this->current_value .= " (" . substr(sprintf('%o', $perms), - 4) . ")";
         return PHPSECINFO_TEST_RESULT_NOTICE;
     }
 
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'Test not run -- currently disabled on Windows OSes');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'save_path is enabled, which is the recommended setting.');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'save_path is disabled, or is set to a
 						common world-writable directory.  This typically allows other users on this server
 						to access session files. You should set	save_path to a non-world-readable directory (750 for example)');

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Session/use_trans_sid.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Session/use_trans_sid.php
@@ -1,37 +1,35 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Test class for session use_trans_sid
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the PhpSecInfo_Test_Session class
  */
-//require_once ('PhpSecInfo/Test/Test_Session.php');
-require_once dirname(__DIR__) . '/Test_Session.php';
+require_once ('PhpSecInfo/Test/Test_Session.php');
 
 /**
  * Test class for session use_trans_sid
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 class PhpSecInfo_Test_Session_Use_Trans_Sid extends PhpSecInfo_Test_Session
 {
+
     /**
      * This should be a <b>unique</b>, human-readable identifier for this test
      *
      * @public string
      */
-
-    public $test_name = 'use_trans_sid';
+    public $test_name = "use_trans_sid";
 
     public $recommended_value = false;
 
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
         $this->current_value = $this->getBooleanIniValue('session.use_trans_sid');
     }
@@ -39,7 +37,7 @@ class PhpSecInfo_Test_Session_Use_Trans_Sid extends PhpSecInfo_Test_Session
     /**
      * Checks to see if allow_url_fopen is enabled
      */
-    public function _execTest()
+    function _execTest()
     {
         if ($this->current_value == $this->recommended_value) {
             return PHPSECINFO_TEST_RESULT_OK;
@@ -51,12 +49,10 @@ class PhpSecInfo_Test_Session_Use_Trans_Sid extends PhpSecInfo_Test_Session
     /**
      * Set the messages specific to this test
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'use_trans_sid is disabled, which is the recommended setting');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'use_trans_sid is enabled. This makes session hijacking easier. Consider disabling this feature');
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test.php
@@ -1,24 +1,21 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file
- *
+ * 
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the main PhpSecInfo class
  */
-//require_once ('PhpSecInfo/PhpSecInfo.php');
-require_once dirname(__DIR__) . '/PhpSecInfo.php';
+require_once ('PhpSecInfo/PhpSecInfo.php');
 
-define('PHPSECINFO_TEST_RESULT_OK', -1);
-define('PHPSECINFO_TEST_RESULT_NOTICE', -2);
-define('PHPSECINFO_TEST_RESULT_WARN', -4);
-define('PHPSECINFO_TEST_RESULT_ERROR', -1024);
-define('PHPSECINFO_TEST_RESULT_NOTRUN', -2048);
+define('PHPSECINFO_TEST_RESULT_OK', - 1);
+define('PHPSECINFO_TEST_RESULT_NOTICE', - 2);
+define('PHPSECINFO_TEST_RESULT_WARN', - 4);
+define('PHPSECINFO_TEST_RESULT_ERROR', - 1024);
+define('PHPSECINFO_TEST_RESULT_NOTRUN', - 2048);
 define('PHPSECINFO_TEST_COMMON_TMPDIR', '/tmp');
 define('PHPSECINFO_TEST_MOREINFO_BASEURL', 'http://phpsec.org/projects/phpsecinfo/tests/');
 
@@ -26,16 +23,18 @@ define('PHPSECINFO_TEST_MOREINFO_BASEURL', 'http://phpsec.org/projects/phpsecinf
  * This is a skeleton class for PhpSecInfo tests You should extend this to make a "group" skeleton
  * to categorize tests under, then make a subdir with your group name that contains test classes
  * extending your group skeleton class.
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test
 {
+
     /**
      * This value is used to group test results together.
      * For example, all tests related to the mysql lib should be grouped under "mysql."
      *
      * @public string
      */
-
     public $test_group = 'misc';
 
     /**
@@ -43,7 +42,6 @@ class PhpSecInfo_Test
      *
      * @public string
      */
-
     public $test_name = 'misc_test';
 
     /**
@@ -51,15 +49,13 @@ class PhpSecInfo_Test
      *
      * @public mixed
      */
-
-    public $recommended_value = 'bar';
+    public $recommended_value = "bar";
 
     /**
      * The result returned from the test
      *
      * @public integer
      */
-
     public $_result = PHPSECINFO_TEST_RESULT_NOTRUN;
 
     /**
@@ -67,7 +63,6 @@ class PhpSecInfo_Test
      *
      * @public string
      */
-
     public $_message;
 
     /**
@@ -76,7 +71,6 @@ class PhpSecInfo_Test
      *
      * @public string
      */
-
     public $_language = PHPSECINFO_LANG_DEFAULT;
 
     /**
@@ -86,17 +80,14 @@ class PhpSecInfo_Test
      *
      * @public string
      */
-
     public $langue_defaut;
-
     public $langue_definie;
-
+    
     /**
      * Enter description here...
      *
      * @public mixed
      */
-
     public $current_value;
 
     /**
@@ -107,17 +98,17 @@ class PhpSecInfo_Test
      *
      * @public array
      */
-
-    public $_messages = [];
+    public $_messages = array();
 
     /**
      * Constructor for Test skeleton class
+     *
+     * @return PhpSecInfo_Test
      */
-    public function __construct()
+    function PhpSecInfo_Test()
     {
         // $this->_setTestValues();
         $this->_retrieveCurrentValue();
-
         // $this->setRecommendedValue();
         $this->_setMessages();
     }
@@ -128,9 +119,9 @@ class PhpSecInfo_Test
      * loaded).
      * This is a terrible name, but I couldn't think of a better one atm.
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         return true;
     }
@@ -139,9 +130,9 @@ class PhpSecInfo_Test
      * The "meat" of the test.
      * This is where the real test code goes. You should override this when extending
      *
-     * @return int
+     * @return integer
      */
-    public function _execTest()
+    function _execTest()
     {
         return PHPSECINFO_TEST_RESULT_NOTRUN;
     }
@@ -152,18 +143,14 @@ class PhpSecInfo_Test
      * messages to be inherited. This is broken out into a separate function rather
      * than the constructor for ease of extension purposes (php4 is whack, man).
      */
-    public function _setMessages()
+    function _setMessages()
     {
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'This setting should be considered safe');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'This could potentially be a security issue');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'This setting may be a serious security problem');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_ERROR, 'en', 'There was an error running this test');
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'This test cannot be run');
-
+        
         // Afichier les messages standards en français c'est très bien, mais, ça me prive des messages anglais exisant qui ne sont pas traduits.
         // $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'fr', 'Ce paramètre devrait pouvoir être considéré comme sûr');
         // $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'fr', 'Ceci pourrait potentiellement être un problème de sécurité');
@@ -175,27 +162,26 @@ class PhpSecInfo_Test
     /**
      * Placeholder - extend for tests
      */
-    public function _retrieveCurrentValue()
+    function _retrieveCurrentValue()
     {
-        $this->current_value = 'foo';
+        $this->current_value = "foo";
     }
 
     /**
      * This is the wrapper that executes the test and sets the result code and message
      */
-    public function test()
+    function test()
     {
         $result = $this->_execTest();
-
         $this->_setResult($result);
     }
 
     /**
      * Retrieves the result
      *
-     * @return int
+     * @return integer
      */
-    public function getResult()
+    function getResult()
     {
         return $this->_result;
     }
@@ -205,9 +191,9 @@ class PhpSecInfo_Test
      *
      * @return string
      */
-    public function getMessage()
+    function getMessage()
     {
-        if (!isset($this->_message) || empty($this->_message)) {
+        if (! isset($this->_message) || empty($this->_message)) {
             $this->_setMessage($this->_result, $this->_language);
         }
 
@@ -220,18 +206,18 @@ class PhpSecInfo_Test
      * $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'This test cannot be run');
      * </code>
      *
-     * @param int    $result_code
+     * @param integer $result_code
      * @param string $language_code
      * @param string $message
      */
-    public function setMessageForResult($result_code, $language_code, $message)
+    function setMessageForResult($result_code, $language_code, $message)
     {
-        if (!isset($this->_messages[$result_code])) {
-            $this->_messages[$result_code] = [];
+        if (! isset($this->_messages[$result_code])) {
+            $this->_messages[$result_code] = array();
         }
 
-        if (!is_array($this->_messages[$result_code])) {
-            $this->_messages[$result_code] = [];
+        if (! is_array($this->_messages[$result_code])) {
+            $this->_messages[$result_code] = array();
         }
 
         $this->_messages[$result_code][$language_code] = $message;
@@ -244,7 +230,7 @@ class PhpSecInfo_Test
      *
      * @return string
      */
-    public function getCurrentTestValue()
+    function getCurrentTestValue()
     {
         return $this->getStringValue($this->current_value);
     }
@@ -256,7 +242,7 @@ class PhpSecInfo_Test
      *
      * @return string
      */
-    public function getRecommendedTestValue()
+    function getRecommendedTestValue()
     {
         return $this->getStringValue($this->recommended_value);
     }
@@ -264,9 +250,9 @@ class PhpSecInfo_Test
     /**
      * Sets the result code
      *
-     * @param int $result_code
+     * @param integer $result_code
      */
-    public function _setResult($result_code)
+    function _setResult($result_code)
     {
         $this->_result = $result_code;
     }
@@ -274,26 +260,25 @@ class PhpSecInfo_Test
     /**
      * Sets the $this->_message variable based on the passed result and language codes
      *
-     * @param int    $result_code
+     * @param integer $result_code
      * @param string $language_code
      */
-    public function _setMessage($result_code, $language_code)
+    function _setMessage($result_code, $language_code)
     {
         $messages = $this->_messages[$result_code];
 
         // Afficher le français par défaut, et, sinon, la langue anglaise quand la traduction n'existe pas.
         // $message = $messages[$language_code];
-        if (isset($messages[$language_code]) && $messages[$language_code] === $this->_language) {
+        if ( $messages[$language_code] === $_language )
+        {
             // $langue_defaut et $langue_definie ne devraient pas être appelées avec public ?
-            $langue_defaut = 'en';
-
+            $langue_defaut ="en";
             $message = $messages[$langue_defaut];
         } else {
             $langue_definie = PHPSECINFO_LANG_DEFAULT;
-
-            $message = isset($messages[$language_code]) ? $messages[$langue_definie] : '';
+            $message = $messages[$langue_definie];
         }
-
+        
         $this->_message = $message;
     }
 
@@ -301,18 +286,18 @@ class PhpSecInfo_Test
      * Returns a link to a page with detailed information about the test
      * URL is formatted as PHPSECINFO_TEST_MOREINFO_BASEURL + testName
      *
-     * @return string|bool
      * @see PHPSECINFO_TEST_MOREINFO_BASEURL
+     * @return string|boolean
      */
-    public function getMoreInfoURL()
+    function getMoreInfoURL()
     {
         if ($tn = $this->getTestName()) {
             // Fixed URL for 'More Information URL'.
             // https://github.com/bigdeej/PhpSecInfo/commit/f8262613ef6da51e65aa8cf31d9b4f80acb15afd#diff-0d32928ec88998768a1fb2d4fc810e19
-            return PHPSECINFO_TEST_MOREINFO_BASEURL . mb_strtolower($tn);
+            return PHPSECINFO_TEST_MOREINFO_BASEURL . strtolower($tn);
+        } else {
+            return false;
         }
-
-        return false;
     }
 
     /**
@@ -321,13 +306,13 @@ class PhpSecInfo_Test
      *
      * @return string
      */
-    public function getTestName()
+    function getTestName()
     {
-        if (isset($this->test_name) && !empty($this->test_name)) {
+        if (isset($this->test_name) && ! empty($this->test_name)) {
             return $this->test_name;
+        } else {
+            return ucwords(str_replace('_', ' ', get_class($this)));
         }
-
-        return ucwords(str_replace('_', ' ', get_class($this)));
     }
 
     /**
@@ -335,7 +320,7 @@ class PhpSecInfo_Test
      *
      * @param string $test_name
      */
-    public function setTestName($test_name)
+    function setTestName($test_name)
     {
         $this->test_name = $test_name;
     }
@@ -345,7 +330,7 @@ class PhpSecInfo_Test
      *
      * @return string
      */
-    public function getTestGroup()
+    function getTestGroup()
     {
         return $this->test_group;
     }
@@ -355,7 +340,7 @@ class PhpSecInfo_Test
      *
      * @param string $test_group
      */
-    public function setTestGroup($test_group)
+    function setTestGroup($test_group)
     {
         $this->test_group = $test_group;
     }
@@ -370,24 +355,28 @@ class PhpSecInfo_Test
      *
      * @link http://php.net/manual/en/function.ini-get.php
      * @param string $val
-     * @return int
+     * @return integer
      */
-    public function returnBytes($val)
+    function returnBytes($val)
     {
-        if (0 === (int)$val) {
+        $val = trim($val);
+
+        if ((int) $val === 0) {
             return 0;
         }
 
-        switch (mb_strtolower(substr((string)$val, -1))) {
-            case 'm':
-                return (int)$val * 1048576;
-            case 'k':
-                return (int)$val * 1024;
+        $last = strtolower($val{strlen($val) - 1});
+        switch ($last) {
+            // The 'G' modifier is available since PHP 5.1.0
             case 'g':
-                return (int)$val * 1073741824;
-            default:
-                return $val;
+                $val *= 1024;
+            case 'm':
+                $val *= 1024;
+            case 'k':
+                $val *= 1024;
         }
+
+        return $val;
     }
 
     /**
@@ -398,13 +387,13 @@ class PhpSecInfo_Test
      * @param mixed $val
      * @return string
      */
-    public function getStringValue($val)
+    function getStringValue($val)
     {
-        if (false === $val) {
-            return '0';
+        if ($val === false) {
+            return "0";
+        } else {
+            return (string) $val;
         }
-
-        return (string)$val;
     }
 
     /**
@@ -416,31 +405,34 @@ class PhpSecInfo_Test
      *
      * @param string $ini_key
      *            the ini_key you need the value of
-     * @return bool|mixed
+     * @return boolean|mixed
      */
-    public function getBooleanIniValue($ini_key)
+    function getBooleanIniValue($ini_key)
     {
         $ini_val = ini_get($ini_key);
 
-        if (is_string($ini_val)) {
-            $ini_val = mb_strtolower($ini_val);
-        }
-
-        switch ($ini_val) {
+        switch (strtolower($ini_val)) {
             case 'off':
                 return false;
+                break;
             case 'on':
                 return true;
+                break;
             case 'false':
                 return false;
+                break;
             case 'true':
                 return true;
+                break;
             case '0':
                 return false;
+                break;
             case '1':
                 return true;
+                break;
             case '':
                 return false;
+                break;
             default:
                 return $ini_val;
         }
@@ -451,39 +443,35 @@ class PhpSecInfo_Test
      * that is lacking in versions of PHP that do not have the
      * sys_get_temp_dir() function
      *
-     * @return string|null
+     * @return string|NULL
      */
-    public function sys_get_temp_dir()
+    function sys_get_temp_dir()
     {
         // Try to get from environment variable
-        if (!empty($_ENV['TMP'])) {
+        if (! empty($_ENV['TMP'])) {
             return realpath($_ENV['TMP']);
-        }
-
-        if (!empty($_ENV['TMPDIR'])) {
+        } elseif (! empty($_ENV['TMPDIR'])) {
             return realpath($_ENV['TMPDIR']);
-        }
-
-        if (!empty($_ENV['TEMP'])) {
+        } elseif (! empty($_ENV['TEMP'])) {
             return realpath($_ENV['TEMP']);
+        } else {
+            return null;
         }
-
-        return null;
     }
 
     /**
      * A quick function to determine whether we're running on Windows.
      * Uses the PHP_OS constant.
      *
-     * @return bool
+     * @return boolean
      */
-    public function osIsWindows()
+    function osIsWindows()
     {
-        if (0 === mb_stripos(PHP_OS, 'WIN')) {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             return true;
+        } else {
+            return false;
         }
-
-        return false;
     }
 
     /**
@@ -495,65 +483,48 @@ class PhpSecInfo_Test
      * returns FALSE if no suitable function is available to retrieve
      * the data
      *
-     * @return array|bool
+     * @return array|boolean
      */
-    public function getUnixId()
+    function getUnixId()
     {
         if ($this->osIsWindows()) {
             return false;
-        }
-
-        if (function_exists('exec') && !$this->getBooleanIniValue('safe_mode')) {
+        } elseif (function_exists("exec") && ! PhpSecInfo_Test::getBooleanIniValue('safe_mode')) {
             $id_raw = exec('id');
-
             // uid=1000(coj) gid=1000(coj) groups=1000(coj),1001(admin)
             preg_match("|uid=(\d+)\((\S+)\)\s+gid=(\d+)\((\S+)\)\s+groups=(.+)|i", $id_raw, $matches);
 
-            $id_data = [
-                'uid'      => $matches[1],
+            $id_data = array(
+                'uid' => $matches[1],
                 'username' => $matches[2],
-                'gid'      => $matches[3],
-                'group'    => $matches[4],
-            ];
+                'gid' => $matches[3],
+                'group' => $matches[4]
+            );
 
             if ($matches[5]) {
                 $gs = $matches[5];
-
                 $gs = explode(',', $gs);
-
                 foreach ($gs as $groupstr) {
                     preg_match("/(\d+)\(([^\)]+)\)/", $groupstr, $subs);
-
                     $groups[$subs[1]] = $subs[2];
                 }
-
                 ksort($groups);
-
                 $id_data['groups'] = $groups;
             }
-
             return $id_data;
-        }
-
-        if (function_exists('posix_getpwuid') && function_exists('posix_geteuid') && function_exists('posix_getgrgid') && function_exists('posix_getgroups')) {
+        } elseif (function_exists("posix_getpwuid") && function_exists("posix_geteuid") && function_exists('posix_getgrgid') && function_exists('posix_getgroups')) {
             $data = posix_getpwuid(posix_getuid());
-
             $id_data['uid'] = $data['uid'];
-
             $id_data['username'] = $data['name'];
-
             $id_data['gid'] = $data['gid'];
-
             // $group_data = posix_getgrgid( posix_getegid() );
             // $id_data['group'] = $group_data['name'];
             $groups = posix_getgroups();
-
             foreach ($groups as $gid) {
                 // $group_data = posix_getgrgid(posix_getgid());
                 $id_data['groups'][$gid] = '<unknown>';
             }
         }
-
         return false;
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Cgi.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Cgi.php
@@ -1,24 +1,24 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for Cgi group
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * require the main PhpSecInfo class
  */
-//require_once ('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
+require_once ('PhpSecInfo/Test/Test.php');
 
 /**
  * This is a skeleton class for PhpSecInfo "CGI" tests
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Cgi extends PhpSecInfo_Test
 {
+
     /**
      * This value is used to group test results together.
      *
@@ -26,7 +26,6 @@ class PhpSecInfo_Test_Cgi extends PhpSecInfo_Test
      *
      * @public string
      */
-
     public $test_group = 'CGI';
 
     /**
@@ -34,9 +33,9 @@ class PhpSecInfo_Test_Cgi extends PhpSecInfo_Test
      * The best way I could think of
      * to test this was to preg against the php_sapi_name() return value.
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         /*
          * if ( preg_match('/^cgi.*$/', php_sapi_name()) ) {
@@ -45,17 +44,15 @@ class PhpSecInfo_Test_Cgi extends PhpSecInfo_Test
          * return false;
          * }
          */
-
-        return 0 === mb_strpos(PHP_SAPI, 'cgi');
+        return strpos(php_sapi_name(), 'cgi') === 0;
     }
 
     /**
      * Set the messages for CGI tests
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', "You don't seem to be using the CGI SAPI");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Core.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Core.php
@@ -1,39 +1,37 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for Core group
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * require the main PhpSecInfo class
  */
-//require_once('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
+require_once('PhpSecInfo/Test/Test.php');
 
 /**
  * This is a skeleton class for PhpSecInfo "Core" tests
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Core extends PhpSecInfo_Test
 {
+    
     /**
      * This value is used to group test results together.
      * For example, all tests related to the mysql lib should be grouped under "mysql."
      *
      * @public string
      */
-
     public $test_group = 'Core';
-
+    
     /**
      * "Core" tests should pretty much be always testable, so the default is just to return true
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         return true;
     }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Curl.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Curl.php
@@ -1,58 +1,54 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for ` group
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the main PhpSecInfo class
  */
-//require_once('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
+require_once('PhpSecInfo/Test/Test.php');
 
 /**
  * This is a skeleton class for PhpSecInfo "Curl" tests
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Curl extends PhpSecInfo_Test
 {
+
     /**
      * This value is used to group test results together.
      * For example, all tests related to the mysql lib should be grouped under "mysql."
      *
      * @public string
      */
-
     public $test_group = 'Curl';
 
     /**
      * "Curl" tests should only be run if the curl extension is installed.  We can check
      * for this by seeing if the function curl_init() is defined
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
-        /*      if ( function_exists('curl_init') ) {
-                    return true;
-                } else {
-                    return false;
-                }
-        */
-
+/*      if ( function_exists('curl_init') ) {
+            return true;
+        } else {
+            return false;
+        }
+*/
         return extension_loaded('curl');
     }
 
     /**
      * Set the messages for Curl tests
      */
-    public function _setMessages()
+    function _setMessages()
     {
         parent::_setMessages();
-
-        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'CURL support is not enabled in your PHP install');
+        $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', "CURL support is not enabled in your PHP install");
     }
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Dir.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Dir.php
@@ -1,40 +1,39 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for Dir group
- *
+ * 
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 /**
  * require the main PhpSecInfo class
  */
-//require_once('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
-
+require_once('PhpSecInfo/Test/Test.php');
 /**
  * This is a skeleton class for PhpSecInfo "Dir" tests
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Dir extends PhpSecInfo_Test
 {
-    /**
-     * This value is used to group test results together.
-     *
-     * For example, all tests related to the mysql lib should be grouped under "mysql."
-     *
-     * @public string
-     */
-
-    public $test_group = 'Dir';
-
-    /**
-     * "Dir" tests should pretty much be always testable, so the default is just to return true
-     *
-     * @return bool
-     */
-    public function isTestable()
-    {
-        return true;
-    }
+	
+	/**
+	 * This value is used to group test results together.
+	 * 
+	 * For example, all tests related to the mysql lib should be grouped under "mysql."
+	 *
+	 * @public string
+	 */
+	public $test_group = 'Dir';
+	
+	
+	/**
+	 * "Dir" tests should pretty much be always testable, so the default is just to return true
+	 * 
+	 * @return boolean
+	 */
+	function isTestable() {
+		
+		return true;
+	}
+	
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Functions.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Functions.php
@@ -1,40 +1,36 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for Core group
- *
+ * 
+ * @package PhpSecInfo
  * @author Glenn S Crystal <glenn@gcosoftware.com>
  */
 
 /**
  * Require the main PhpSecInfo class
  */
-//require_once('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
+require_once('PhpSecInfo/Test/Test.php');
 
 /**
  * This is a skeleton class for PhpSecInfo "Functions" tests
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Functions extends PhpSecInfo_Test
 {
-    /**
-     * This value is used to group test results together.
-     * For example, all tests related to the mysql lib should be grouped under "mysql."
-     *
-     * @public string
-     */
-
-    public $test_group = 'Functions';
-
-    /**
-     * "Functions" tests should pretty much be always testable, so the default is just to return true.
-     *
-     * @return bool
-     */
-    public function isTestable()
-    {
-        return true;
-    }
+	/**
+	 * This value is used to group test results together. 
+	 * For example, all tests related to the mysql lib should be grouped under "mysql."
+	 *
+	 * @public string
+	 */
+	public $test_group = 'Functions';
+	
+	/**
+	 * "Functions" tests should pretty much be always testable, so the default is just to return true.
+	 * 
+	 * @return boolean
+	 */
+	function isTestable() {	
+		return true;
+	}	
 }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Session.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/Test/Test_Session.php
@@ -1,40 +1,39 @@
 <?php
-
-declare(strict_types=1);
-
 /**
  * Skeleton Test class file for Session group
  *
+ * @package PhpSecInfo
  * @author Ed Finkler <coj@funkatron.com>
  */
 
 /**
  * Require the main PhpSecInfo class
  */
-//require_once('PhpSecInfo/Test/Test.php');
-require_once __DIR__ . '/Test.php';
+require_once ('PhpSecInfo/Test/Test.php');
 
 /**
  * This is a skeleton class for PhpSecInfo "Session" tests
+ *
+ * @package PhpSecInfo
  */
 class PhpSecInfo_Test_Session extends PhpSecInfo_Test
 {
+
     /**
      * This value is used to group test results together.
      * For example, all tests related to the mysql lib should be grouped under "mysql."
      *
      * @public string
      */
-
     public $test_group = 'Session';
 
     /**
      * "Session" tests should pretty much be always testable, so the default is just to
      * return true
      *
-     * @return bool
+     * @return boolean
      */
-    public function isTestable()
+    function isTestable()
     {
         return true;
     }

--- a/2019-phpsecinfo-v3.0.1/PhpSecInfo/phpinfo.php
+++ b/2019-phpsecinfo-v3.0.1/PhpSecInfo/phpinfo.php
@@ -1,18 +1,17 @@
 <?php
-
-declare(strict_types=1);
-
 /**
- * Page phpinfo() | PhpSecInfo/phpinfo.php
- *
- * @author Zer00CooL <mail@visionduweb.com>
- */
+* Page phpinfo() | PhpSecInfo/phpinfo.php
+*
+* @package PhpSecInfo
+* @author Zer00CooL <mail@visionduweb.com>
+*/
+
 echo '<a href="../">Revenir sur PhpSecInfo</a>';
 echo '<br/>';
 
 /**
  * Fonction phpinfo() | PhpSecInfo/phpinfo.php
  *
- * @return string|bool
+ * @return string|boolean
  */
 phpinfo();

--- a/2019-phpsecinfo-v3.0.1/index.php
+++ b/2019-phpsecinfo-v3.0.1/index.php
@@ -1,12 +1,10 @@
-<?php declare(strict_types=1);
-
-require_once('PhpSecInfo/PhpSecInfo.php'); ?>
+<?php require_once('PhpSecInfo/PhpSecInfo.php'); ?>
 <?php phpsecinfo(); ?>
 
 <?php
 /* ## EN ##
  * ## EN ## This is an example page calling the phpsecinfo() function
- *
+ * 
  * If you want to capture output and/or customize the look and feel,
  * you need to do slightly more work.
  *
@@ -33,7 +31,7 @@ require_once('PhpSecInfo/PhpSecInfo.php'); ?>
  *
  * ## FR ##
  * ## FR ## Ceci est un exemple de page appelant la fonction phpsecinfo()
- *
+ * 
  * Si vous souhaitez capturer la sortie et/ou personnaliser l'apparence,
  * vous devez faire un peu plus de travail.
  *


### PR DESCRIPTION
Reverts ZerooCool/phpsecinfo#25

With this Pull request, if i choose French version, then, when we have a translation in french, words in english are not set.

I need look for a better solution.

Example : 


upload_max_filesize | Notice                                 upload_max_filesize  is not enabled, or is set to a high value.  Are you sure your apps  require uploading files of this size?  If not, lower the limit, as large  file uploads can impact server performance                                                                                    					Valeur actuelle  					 					 					83886080 				                                                                  					Valeur recommandée 					33554432 | Valeur actuelle | 83886080 | Valeur recommandée | 33554432
-- | -- | -- | -- | -- | --
Valeur actuelle | 83886080
Valeur recommandée | 33554432


give ->
we loose the description.


upload_max_filesize | Notice                                                                                                                                                                                                                     Valeur actuelle                                                                                                                            83886080                                                                                                                                                                                   Valeur recommandée                                         33554432 | Valeur actuelle | 83886080 | Valeur recommandée | 33554432
-- | -- | -- | -- | -- | --
Valeur actuelle | 83886080
Valeur recommandée | 33554432

